### PR TITLE
Mechanism to translate timestamps between globals

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>High Resolution Time Level 2</title>
+  <title>High Resolution Time Level 3</title>
   <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class=
   'remove'>
   </script>
   <script class='remove'>
   var respecConfig = {
-    shortName: "hr-time-2",
+    shortName: "hr-time-3",
     specStatus: "ED",
     useExperimentalStyles: true,
     edDraftURI: "https://w3c.github.io/hr-time/",
@@ -90,22 +90,11 @@
     skew or adjustments.</p>
   </section>
   <section id="sotd">
-    <p>High Resolution Time Level 2 replaces the first version of High
+    <p>High Resolution Time Level 3 replaces the second version of High
     Resolution Time [[HR-TIME]] and includes:</p>
     <ul>
-      <li>Defines a precise definition of <a>time origin</a> for the purpose of
-      all performance timeline related specifications;
-      </li>
       <li>Defines <a>performance.timeOrigin</a> attribute that provides the
       global time of the zero time of <a>time origin</a>;
-      </li>
-      <li>Provides the base definition for the <a>Performance</a> interface,
-      including support for the <a>Performance.now</a> method in Web Workers
-      [[WORKERS]];
-      </li>
-      <li>To mitigate <a href='#privacy-security'>cache attacks</a>, the
-      recommended minimum resolution of the Performance interface should be set
-      to 5 microseconds.
       </li>
     </ul>
   </section>
@@ -159,7 +148,7 @@ var duration = Date.now() - mark_start;
     <code>Date.now()</code> [[ECMA-262]] as it is genuinely useful in
     determining the current value of the calendar time and has a long history
     of usage. The <a>DOMHighResTimeStamp</a> type, <a>performance.now</a>
-    method, and <a>performance.timeOrigin</a> attribute of the
+    method, and <a>performance.timeOrigin</a> attributes of the
     <a>Performance</a> interface resolve above issues by providing
     monotonically increasing time values with sub-millisecond resolution.</p>
     <section id='examples' class='informative'>
@@ -181,11 +170,11 @@ onconnect = function(e) {
     result = runSomeWorkerTask();
     var task_end = performance.now();
 
+    // Send results and epoch-relative timestamps to another context
     port.postMessage({
        'task': 'Some worker task',
-       'time_origin': performance.timeOrigin,
-       'start_time': task_start,
-       'end_time': task_end,
+       'start_time': task_start + performance.timeOrigin,
+       'end_time': task_end + performance.timeOrigin,
        'result': result
     });
   }
@@ -209,20 +198,13 @@ var worker = new SharedWorker('worker.js');
 worker.port.onmessage = function (event) {
   var msg = event.data;
 
-  // calculate time origin offset between document and sender context's
-  var offset = msg.time_origin - performance.timeOrigin;
-
-  // translate timestamps into document's time origin
-  msg.start_time = msg.start_time + offset;
-  msg.end_time = msg.end_time + offset;
+  // translate epoch-relative timestamps into document's time origin
+  msg.start_time = msg.start_time - performance.timeOrigin;
+  msg.end_time = msg.end_time - performance.timeOrigin;
 
   // plot the results on document's timeline
   plotEventOnTimeline(msg);
 }</pre>
-      <p>Alternatively, instead of the receiver performing the translation, the
-      sender context could also perform the offset calculation locally and
-      transmit the global times to the reciever. The application developer can
-      decide which is more preferrable based on their needs.</p>
     </section>
   </section>
   <section id="conformance">
@@ -279,7 +261,7 @@ worker.port.onmessage = function (event) {
     <ul>
       <li>If <a>time origin</a> is undefined, return `undefined`.
       </li>
-      <li>Otherwise, the sum of the high resolution UTC epoch time at which the
+      <li>Otherwise, the sum of the high resolution [Unix time] at which the
       <a>global monotonic clock</a> is zero and the time value of the <a>global
       monotonic clock</a> at which the <a>time origin</a> is zero.
       </li>
@@ -292,9 +274,9 @@ worker.port.onmessage = function (event) {
   </section>
   <section id="dom-domhighrestimestamp">
     <h3>The <code>DOMHighResTimeStamp</code> Type</h3>
-    <p>The <a>DOMHighResTimeStamp</a> type is used to store a time value
-    measured relative from the <a>time origin</a>, <a>global monotonic
-    clock</a>, or a time value that represents a duration between two
+    <p>The <a>DOMHighResTimeStamp</a> type is used to store a time value in
+    milliseconds, measured relative from the <a>time origin</a>, <a>global
+    monotonic clock</a>, or a time value that represents a duration between two
     <a>DOMHighResTimeStamp</a>'s.</p>
     <pre class='idl'>
 typedef double DOMHighResTimeStamp;
@@ -312,7 +294,7 @@ typedef double DOMHighResTimeStamp;
 [Exposed=(Window,Worker)]
 interface Performance : EventTarget {
     DOMHighResTimeStamp now ();
-    attribute DOMHighResTimeStamp timeOrigin;
+    readonly attribute DOMHighResTimeStamp timeOrigin;
     serializer = {attribute};
 };
 </pre>
@@ -351,54 +333,86 @@ WorkerGlobalScope implements GlobalPerformance;
     have the same <a>time origin</a>.</p>
     <p>The time values returned when getting <a>performance.timeOrigin</a> MUST
     use the same <dfn>global monotonic clock</dfn> that is shared by <a>time
-    origin</a>'s and is monotonically increasing and not subject to system
-    clock adjustments or system clock skew.</p>
+    origin</a>'s, is monotonically increasing and not subject to system clock
+    adjustments or system clock skew, and whose reference point is the Unix
+    time—see <a href="privacy-security"></a>.</p>
+    <p class="note">The user agent can reset its global monotonic clock across
+    browser restarts, or whenever starting an isolated browsing session—e.g.
+    incognito or similar browsing mode. As a result, developers should not use
+    global timestamps as absolute time that holds its monotonic properties
+    across all past, present, and future contexts; in practice, the monotonic
+    properties only apply for contexts that can reach other by exchanging
+    messages via one of the provided messaging mechanisms - e.g. `postMessage`,
+    `BroadcastChannel`, etc.</p>
   </section>
   <section id="privacy-security">
     <h3>Privacy and Security</h3>
-    <p>Access to accurate timing information, both for measurement and
-    scheduling purposes, is a common requirement for many applications. For
-    example, coordinating animations, sound, and other activity on the page
-    requires access to high-resolution time to provide a good user experience.
-    Similarly, measurement enables developers to track the performance of
-    critical code components, detect regressions, and so on.</p>
-    <p>However, access to the same accurate timing information can sometimes be
-    also used for malicious purposes by an attacker to guess and infer data
-    that they can't see or access otherwise. For example, cache attacks and
-    statistical fingerprinting is a privacy and security concern where a
-    malicious web site may use high resolution timing data of various browser
-    or application-initiated operations to differentiate between subset of
-    users, and in some cases identify a particular user - see
-    [[CACHE-ATTACKS]].</p>
-    <p>This specification defines an API that provides sub-millisecond time
-    resolution, which is more accurate than the previously available
-    millisecond resolution exposed by [DOMTimeStamp]. However, even without
-    this new API an attacker may be able to obtain high-resolution estimates
-    through repeat execution and statistical analysis. To ensure that the new
-    API does not significantly improve the accuracy or speed of such attacks,
-    the recommended minimum resolution of the <a>Performance</a> interface
-    should be set to 5 microseconds.</p>
-    <p>Mitigating such timing side-channel attacks entirely is practically not
-    possible: either all operations would have to execute in a time that does
-    not vary based on the value of any confidential information, or, the
-    application would need to be isolated from any time-related primitives
-    (clock, timers, counters, etc). Neither is practical due to the associated
-    complexity for the browser and application developers and the associated
-    negative effects on performance and responsiveness of applications.</p>
-    <p>This specification also defines a mechanism to translate high resolution
-    timestamps across <a>time origin</a>'s, which requires a global monotonic
-    clock and may provide additional [clock drift] resolution. Today, the
-    attacker can timestamp the time-of-day and monotonic time values (via
-    `Date.now()` and `performance.now()`) at multiple points within the same
-    context and observe drift between them. With the
-    <a>performance.timeOrigin</a> attribute, the attacker can also compare the
-    time at which <a>time origin</a> is zero, as reported by the global monotic
-    clock, against the current time-of-day estimate of when it is zero (i.e.
-    difference between `Date.now()-performance.now()` and
-    `performance.timeOrigin`) and observe drift between the zero time of the
-    global monotic clock and the current time. To reduce accuracy of such
-    attacks the user agent is recommended to periodically update the zero time
-    time-of-day reference of its global monotonic clock.</p>
+    <section>
+      <h3>Clock resolution</h3>
+      <p>Access to accurate timing information, both for measurement and
+      scheduling purposes, is a common requirement for many applications. For
+      example, coordinating animations, sound, and other activity on the page
+      requires access to high-resolution time to provide a good user
+      experience. Similarly, measurement enables developers to track the
+      performance of critical code components, detect regressions, and so
+      on.</p>
+      <p>However, access to the same accurate timing information can sometimes
+      be also used for malicious purposes by an attacker to guess and infer
+      data that they can't see or access otherwise. For example, cache attacks
+      and statistical fingerprinting is a privacy and security concern where a
+      malicious web site may use high resolution timing data of various browser
+      or application-initiated operations to differentiate between subset of
+      users, and in some cases identify a particular user - see
+      [[CACHE-ATTACKS]].</p>
+      <p>This specification defines an API that provides sub-millisecond time
+      resolution, which is more accurate than the previously available
+      millisecond resolution exposed by [DOMTimeStamp]. However, even without
+      this new API an attacker may be able to obtain high-resolution estimates
+      through repeat execution and statistical analysis. To ensure that the new
+      API does not significantly improve the accuracy or speed of such attacks,
+      the recommended minimum resolution of the <a>Performance</a> interface
+      should be set to 5 microseconds.</p>
+      <p>Mitigating such timing side-channel attacks entirely is practically
+      not possible: either all operations would have to execute in a time that
+      does not vary based on the value of any confidential information, or, the
+      application would need to be isolated from any time-related primitives
+      (clock, timers, counters, etc). Neither is practical due to the
+      associated complexity for the browser and application developers and the
+      associated negative effects on performance and responsiveness of
+      applications.</p>
+    </section>
+    <section>
+      <h3>Clock drift</h3>
+      <p>This specification also defines an API that provides sub-millisecond
+      time resolution of the zero time of the time origin, which requires and
+      exposes a <a>global monotonic clock</a> to the application, and that must
+      be shared across all the browser contexts. The <a>global monotonic
+      clock</a> does not need to be tied to physical time, but is recommended
+      to be set with respect to the [Unix time] to avoid exposing new
+      fingerprint entropy about the user—e.g. this time can already be easily
+      obtained by the application, whereas exposing a new logical clock
+      provides new information.</p>
+      <p>However, even with above mechanism in place, the <a>global monotonic
+      clock</a> may provide additional [clock drift] resolution. Today, the
+      application can timestamp the time-of-day and monotonic time values (via
+      `Date.now()` and `performance.now()`) at multiple points within the same
+      context and observe drift between them—e.g. due to automatic or user
+      clock adjustments. With the <a>performance.timeOrigin</a> attribute, the
+      attacker can also compare the time at which <a>time origin</a> is zero,
+      as reported by the <a>global monotonic clock</a>, against the current
+      time-of-day estimate of when it is zero (i.e. difference between
+      `Date.now()-performance.now()` and `performance.timeOrigin`) and
+      potentially observe clock drift between these clocks over a longer time
+      period.</p>
+      <p>In practice, the same time drift can be observed by an application
+      across multiple navigations: the application can record logical time in
+      each context and use a client or server time synchronization mechanism to
+      infer changes in the user's clock. Similarly, lower-layer mechanisms such
+      as TCP timestamps may reveal same high-resolution information to the
+      server without the need for multiple visits. As such, the information
+      provided by this API should not expose any significant or previously not
+      available entropy about the user.</p>
+    </section>
   </section>
   <section class="appendix">
     <h2>Acknowledgments</h2>
@@ -417,3 +431,4 @@ WorkerGlobalScope implements GlobalPerformance;
 [sharedworker]: http://www.w3.org/TR/workers/#sharedworker
 [global object]: http://www.w3.org/TR/html51/webappapis.html#global-object
 [clock drift]: https://en.wikipedia.org/wiki/Clock_drift
+[Unix time]: https://en.wikipedia.org/wiki/Unix_time

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     wgURI: "http://www.w3.org/2010/webperf/",
     wgPublicList: "public-web-perf",
     subjectPrefix: "[hr-time]",
+    format: "markdown",
     otherLinks: [{
       key: 'Repository',
       data: [{
@@ -95,23 +96,18 @@
       <li>Defines a precise definition of <a>time origin</a> for the purpose of
       all performance timeline related specifications;
       </li>
+      <li>Defines <a>performance.timeOrigin</a> attribute that provides the
+      global time of the zero time of <a>time origin</a>;
+      </li>
       <li>Provides the base definition for the <a>Performance</a> interface,
       including support for the <a>Performance.now</a> method in Web Workers
       [[WORKERS]];
-      </li>
-      <li>Introduces the method <a>Performance.translateTime</a> to compare
-      times between different time origins;
       </li>
       <li>To mitigate <a href='#privacy-security'>cache attacks</a>, the
       recommended minimum resolution of the Performance interface should be set
       to 5 microseconds.
       </li>
     </ul>
-    <p>The method <a>Performance.translateTime</a> is marked as <a href=
-    'http://www.w3.org/2015/Process-20150901/#candidate-rec'>"at risk"</a> to
-    the purpose of moving High Resolution Time 2 to W3C Recommendation due to
-    its lack of implementation experience. It is expected to be deferred until
-    the next release.</p>
   </section>
   <section id="introduction" class='informative'>
     <h2>Introduction</h2>
@@ -119,19 +115,18 @@
     object as a time value representing time in milliseconds since 01 January,
     1970 UTC. For most purposes, this definition of time is sufficient as these
     values represent time to millisecond precision for any instant that is
-    within approximately 285,616 years from 01 January, 1970 UTC. The <a href=
-    "http://www.w3.org/TR/WebIDL/#common-DOMTimeStamp">DOMTimeStamp</a> is
-    defined similarly [[WebIDL]].</p>
+    within approximately 285,616 years from 01 January, 1970 UTC. The
+    [DOMTimeStamp] is defined similarly [[WebIDL]].</p>
     <p>In practice, these definitions of time are subject to both clock skew
     and adjustment of the system clock. The value of time may not always be
     monotonically increasing and subsequent values may either decrease or
     remain the same.</p>
-    <p>For example, the following script may log a positive number, negative
-    number, or zero.</p>
+    <p>For example, the following script may record a positive number, negative
+    number, or zero for computed `duration`:</p>
     <pre class='example highlight'>
 var mark_start = Date.now();
 doTask(); // Some task
-if (window.console) window.console.log('Duration of task: ' + (Date.now() - mark_start));
+var duration = Date.now() - mark_start;
         </pre>
     <p>For certain tasks this definition of time may not be sufficient as it
     does not allow for sub-millisecond resolution and is subject to system
@@ -150,30 +145,32 @@ if (window.console) window.console.log('Duration of task: ' + (Date.now() - mark
       an animation is drawing at 60 FPS. Without sub-millisecond resolution, a
       developer can only determine if an animation is drawing at 58.8 FPS or
       62.5 FPS.</li>
-      <li>In order to cue audio to a specific point in an animation or ensure
-      that the audio is synchronized with the animation, developers will need
-      to accurately know the amount of time elapsed in the animation and
+      <li>When attempting to cue audio to a specific point in an animation or
+      ensure that the audio is synchronized with the animation, developers will
+      need to accurately know the amount of time elapsed in the animation and
       audio.</li>
+      <li>When multiple contexts need to synchronize work with sub-millisecond
+      resolution (e.g. when using [dedicated][dedicatedworker] or
+      [shared][sharedworker] workers to drive animation, audio, etc., in a
+      renderer context), or to create a unified view of the event
+      timeline.</li>
     </ul>
     <p>This specification does not propose changing the behavior of
     <code>Date.now()</code> [[ECMA-262]] as it is genuinely useful in
     determining the current value of the calendar time and has a long history
-    of usage. The <a>DOMHighResTimeStamp</a> type and the
-    <a>Performance.now</a> method of the <a>Performance</a> interface resolve
-    the issues summarized in this section by providing a monotonically
-    increasing time value in sub-millisecond resolution.</p>
+    of usage. The <a>DOMHighResTimeStamp</a> type, <a>performance.now</a>
+    method, and <a>performance.timeOrigin</a> attribute of the
+    <a>Performance</a> interface resolve above issues by providing
+    monotonically increasing time values with sub-millisecond resolution.</p>
     <section id='examples' class='informative'>
       <h3>Examples</h3>
       <p>A developer may wish to construct a timeline of their entire
-      application, including events from <a href=
-      "http://www.w3.org/TR/workers/#worker">dedicated</a> or <a href=
-      "http://www.w3.org/TR/workers/#sharedworker">shared workers</a>, which
-      have a different <a>time origin</a>. To display such events on the same
-      timeline, the application can translate the <a data-lt=
-      "DOMHighResTimeStamp">DOMHighResTimeStamps</a> from the worker with the
-      <a>Performance.translateTime</a> method.</p>
+      application, including events from [dedicated][dedicatedworker] or
+      [shared workers][sharedworker], which have different <a>time
+      origin</a>'s. To display such events on the same timeline, the
+      application can translate the <a>DOMHighResTimeStamp</a>'s with the help
+      of the <a>performance.timeOrigin</a> attribute.</p>
       <pre class="example highlight">
-
 // ---- worker.js -----------------------------
 // Shared worker script
 onconnect = function(e) {
@@ -186,6 +183,7 @@ onconnect = function(e) {
 
     port.postMessage({
        'task': 'Some worker task',
+       'time_origin': performance.timeOrigin,
        'start_time': task_start,
        'end_time': task_end,
        'result': result
@@ -211,14 +209,20 @@ var worker = new SharedWorker('worker.js');
 worker.port.onmessage = function (event) {
   var msg = event.data;
 
+  // calculate time origin offset between document and sender context's
+  var offset = msg.time_origin - performance.timeOrigin;
+
   // translate timestamps into document's time origin
-  msg.start_time = performance.translateTime(msg.start_time, worker);
-  msg.end_time = performance.translateTime(msg.end_time, worker);
+  msg.start_time = msg.start_time + offset;
+  msg.end_time = msg.end_time + offset;
 
   // plot the results on document's timeline
   plotEventOnTimeline(msg);
-}
-</pre>
+}</pre>
+      <p>Alternatively, instead of the receiver performing the translation, the
+      sender context could also perform the offset calculation locally and
+      transmit the global times to the reciever. The application developer can
+      decide which is more preferrable based on their needs.</p>
     </section>
   </section>
   <section id="conformance">
@@ -237,7 +241,7 @@ worker.port.onmessage = function (event) {
       <li>If the <a href=
       "http://www.w3.org/TR/html51/webappapis.html#global-object">global
       object</a> [[!HTML51]] is a <code>Window</code> object, the <a>time
-      origin</a> must be equal to:
+      origin</a> MUST be equal to:
         <ul>
           <li>the time when the <a href=
           "http://www.w3.org/TR/html51/browsers.html#creating-a-new-browsing-context">
@@ -261,7 +265,7 @@ worker.port.onmessage = function (event) {
       "http://www.w3.org/TR/html51/webappapis.html#global-object">global
       object</a> is a <a href=
       "https://w3c.github.io/workers/#the-workerglobalscope-common-interface">
-        <code>WorkerGlobalScope</code></a> object, the <a>time origin</a> must
+        <code>WorkerGlobalScope</code></a> object, the <a>time origin</a> MUST
         be equal to the <a href=
         "https://w3c.github.io/workers/#official-moment-of-creation">official
         moment of creation</a> of the worker. [[!WORKERS]] [[!SERVICE-WORKERS]]
@@ -269,12 +273,29 @@ worker.port.onmessage = function (event) {
       <li>Otherwise, the <a>time origin</a> is undefined.
       </li>
     </ul>
+    <p>The <dfn id="time-origin-timestamp">time origin timestamp</dfn> is the
+    high resolution time value at which <a>time origin</a> is zero. On getting,
+    the `timeOrigin` attribute MUST return:</p>
+    <ul>
+      <li>If <a>time origin</a> is undefined, return `undefined`.
+      </li>
+      <li>Otherwise, the sum of the high resolution UTC epoch time at which the
+      <a>global monotonic clock</a> is zero and the time value of the <a>global
+      monotonic clock</a> at which the <a>time origin</a> is zero.
+      </li>
+    </ul>
+    <p class="note">The <a>time origin timestamp</a> and the value returned by
+    `Date.now()` executed at "zero time" can differ because the former is
+    recorded with respect to a global monotonic clock that is not subject to
+    system and user clock adjustments, clock skew, and so on—see <a href=
+    "#monotonic-clock"></a>.</p>
   </section>
   <section id="dom-domhighrestimestamp">
     <h3>The <code>DOMHighResTimeStamp</code> Type</h3>
     <p>The <a>DOMHighResTimeStamp</a> type is used to store a time value
-    measured relative from the <a>time origin</a> or a time value that
-    represents a duration between two <a>DOMHighResTimeStamp</a>s.</p>
+    measured relative from the <a>time origin</a>, <a>global monotonic
+    clock</a>, or a time value that represents a duration between two
+    <a>DOMHighResTimeStamp</a>'s.</p>
     <pre class='idl'>
 typedef double DOMHighResTimeStamp;
 </pre>
@@ -291,40 +312,23 @@ typedef double DOMHighResTimeStamp;
 [Exposed=(Window,Worker)]
 interface Performance : EventTarget {
     DOMHighResTimeStamp now ();
-    DOMHighResTimeStamp translateTime (DOMHighResTimeStamp time, (Window or Worker or SharedWorker or ServiceWorker) timeSource);
+    attribute DOMHighResTimeStamp timeOrigin;
     serializer = {attribute};
 };
 </pre>
     <p>The <dfn for='Performance' data-lt='now'>now()</dfn> method MUST return
-    a <a>DOMHighResTimeStamp</a> representing the time in milliseconds from the
+    a <a>DOMHighResTimeStamp</a> representing the high resolution time from the
     <a>time origin</a> to the occurrence of the call to the
     <a>Performance.now</a> method.</p>
-    <p>The <dfn for='Performance' data-lt='translateTime'>translateTime(time,
-    timeSource)</dfn> method MUST return a <a>DOMHighResTimeStamp</a> as
-    follows:</p>
-    <ol>
-      <li>Let <var>time</var> be the value of the provided <code>time</code>
-      argument.</li>
-      <li>Let <var>originSource</var> be the <a>time origin</a> of the
-        <a href="http://www.w3.org/TR/html51/webappapis.html#global-object">global
-        object</a> associated with the provided <code>timeSource</code> object.
-      </li>
-      <li>Let <var>originTranslate</var> be the <a>time origin</a> of the
-      <a href=
-      "http://www.w3.org/TR/html51/webappapis.html#global-object">global
-      object</a> associated with the performance object that is the
-      <code>this</code> value for the <a>Performance.translateTime</a> call.
-      </li>
-      <li>Return <var>time</var> + (<var>originSource</var> -
-      <var>originTranslate</var>)</li>
-    </ol>
+    <p>The <dfn for='Performance' data-lt=
+    'time-origin-timestamp'>timeOrigin</dfn> attribute MUST return a
+    <a>DOMHighResTimeStamp</a> representing the high resolution time of the
+    <a>time origin timestamp</a> of the [global object].</p>
   </section>
   <section>
     <h3>The <code>performance</code> attribute</h3>
     <p>The <a>GlobalPerformance.performance</a> attribute allows access to
-    performance related attributes and methods from the <a href=
-    "http://www.w3.org/TR/html51/webappapis.html#global-object">global
-    object</a>.</p>
+    performance related attributes and methods from the [global object].</p>
     <pre class='idl'>
 [NoInterfaceObject, Exposed=(Window,Worker)]
 interface GlobalPerformance {
@@ -339,13 +343,16 @@ WorkerGlobalScope implements GlobalPerformance;
   <section id="monotonic-clock">
     <h3>Monotonic Clock</h3>
     <p>The time values returned when calling the <a>Performance.now</a> method
-    on <a>Performance</a> objects with the same <a>time origin</a> MUST be
-    monotonically increasing and not subject to system clock adjustments or
-    system clock skew. The difference between any two chronologically recorded
-    time values returned from the <a>Performance.now</a> method MUST never be
-    negative if the two time values have the same <a>time origin</a>.
-    <a>Performance.translateTime</a> MUST be used to compare two
-    chronologically recorded time values of different <a>time origin</a>.</p>
+    on <a>Performance</a> objects with the same <a>time origin</a> MUST use the
+    same <dfn>monotonic clock</dfn> that is monotonically increasing and not
+    subject to system clock adjustments or system clock skew. The difference
+    between any two chronologically recorded time values returned from the
+    <a>Performance.now</a> method MUST never be negative if the two time values
+    have the same <a>time origin</a>.</p>
+    <p>The time values returned when getting <a>performance.timeOrigin</a> MUST
+    use the same <dfn>global monotonic clock</dfn> that is shared by <a>time
+    origin</a>'s and is monotonically increasing and not subject to system
+    clock adjustments or system clock skew.</p>
   </section>
   <section id="privacy-security">
     <h3>Privacy and Security</h3>
@@ -365,20 +372,33 @@ WorkerGlobalScope implements GlobalPerformance;
     [[CACHE-ATTACKS]].</p>
     <p>This specification defines an API that provides sub-millisecond time
     resolution, which is more accurate than the previously available
-    millisecond resolution exposed by <a href=
-    "http://www.w3.org/TR/WebIDL/#common-DOMTimeStamp">DOMTimeStamp</a>.
-    However, even without this new API an attacker may be able to obtain
-    high-resolution estimates through repeat execution and statistical
-    analysis. To ensure that the new API does not significantly improve the
-    accuracy or speed of such attacks, the recommended minimum resolution of
-    the <a>Performance</a> interface should be set to 5 microseconds.</p>
-    <p>Mitigating such timing side channel attacks entirely is practically not
+    millisecond resolution exposed by [DOMTimeStamp]. However, even without
+    this new API an attacker may be able to obtain high-resolution estimates
+    through repeat execution and statistical analysis. To ensure that the new
+    API does not significantly improve the accuracy or speed of such attacks,
+    the recommended minimum resolution of the <a>Performance</a> interface
+    should be set to 5 microseconds.</p>
+    <p>Mitigating such timing side-channel attacks entirely is practically not
     possible: either all operations would have to execute in a time that does
     not vary based on the value of any confidential information, or, the
     application would need to be isolated from any time-related primitives
     (clock, timers, counters, etc). Neither is practical due to the associated
     complexity for the browser and application developers and the associated
     negative effects on performance and responsiveness of applications.</p>
+    <p>This specification also defines a mechanism to translate high resolution
+    timestamps across <a>time origin</a>'s, which requires a global monotonic
+    clock and may provide additional [clock drift] resolution. Today, the
+    attacker can timestamp the time-of-day and monotonic time values (via
+    `Date.now()` and `performance.now()`) at multiple points within the same
+    context and observe drift between them. With the
+    <a>performance.timeOrigin</a> attribute, the attacker can also compare the
+    time at which <a>time origin</a> is zero, as reported by the global monotic
+    clock, against the current time-of-day estimate of when it is zero (i.e.
+    difference between `Date.now()-performance.now()` and
+    `performance.timeOrigin`) and observe drift between the zero time of the
+    global monotic clock and the current time. To reduce accuracy of such
+    attacks the user agent is recommended to periodically update the zero time
+    time-of-day reference of its global monotonic clock.</p>
   </section>
   <section class="appendix">
     <h2>Acknowledgments</h2>
@@ -390,3 +410,10 @@ WorkerGlobalScope implements GlobalPerformance;
   </section>
 </body>
 </html>
+
+<!-- spec references. preserve before running tidy! -->
+[DOMTimeStamp]: http://www.w3.org/TR/WebIDL/#common-DOMTimeStamp
+[dedicatedworker]: http://www.w3.org/TR/workers/#worker
+[sharedworker]: http://www.w3.org/TR/workers/#sharedworker
+[global object]: http://www.w3.org/TR/html51/webappapis.html#global-object
+[clock drift]: https://en.wikipedia.org/wiki/Clock_drift


### PR DESCRIPTION
A first run at exposing ~globalOffset like mechanism to translate timestamps between globals:

Preview: https://cdn.rawgit.com/w3c/hr-time/offset/index.html

- introduces a requirement for a global monotonic clock (see #21)
- there was some pushback on `globalOffset` (see #22) name at the f2f, so I'm using `timeOrigin`
  - the "time origin timestamp" is the zero time for the time origin of the current global
  - at the moment I'm allowing the timestamp to be any value - i.e. not necessarily tied to unix epoch

I'm sure the above needs more work, but hopefully it's a step in the right direction..

/cc @toddreifsteck @sicking for review.