### PR TITLE
Improve latest version headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,12 @@
   <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class=
   'remove'>
   </script>
+  <script src='respec-extensions.js' class='remove'>
+  </script>
   <script class='remove'>
   var respecConfig = {
     shortName: "hr-time-3",
+    latestShortName: "hr-time",
     specStatus: "ED",
     edDraftURI: "https://w3c.github.io/hr-time/",
     editors: [{
@@ -78,6 +81,7 @@
         date: 'March 2015'
       }
     },
+    postProcess: [ enhanceLatestVersions ],
     wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/45211/status"
   };
   </script>

--- a/respec-extensions.js
+++ b/respec-extensions.js
@@ -1,0 +1,44 @@
+(function () {
+  function expose(name, obj) {
+    window[name] = obj;
+  }
+  function getHeaders() {
+    var headers = document.querySelectorAll("#respecHeader dl dt");
+    var obj = {};
+    for ( var i = 0; i < headers.length ; i++) {
+      var header = headers[i];
+      obj[header.textContent] = { "header": header,
+        field: header.nextElementSibling }; 
+    }
+    return obj;
+  }
+  function enhanceLatestVersions() {
+    console.log("Enhancing latest versions...");
+    var title = document.querySe
+    var shortName = window.respecConfig.shortName;
+    var latestShortName = window.respecConfig.latestShortName;
+    if (latestShortName === undefined) {
+      // abort
+      return;
+    }
+    var headers = getHeaders();
+    // change the Latest published version
+    var latestVersion = headers["Latest published version:"];
+    latestVersion.header.textContent = "Latest version of " +
+      document.title + ":";
+    // add a new latest version
+    var dt = document.createElement("dt");
+    var dd = document.createElement("dd");
+    var a = document.createElement("a");
+    var link = "https://www.w3.org/TR/" + latestShortName + "/";
+    a.href = link;
+    a.textContent = link;
+    dd.appendChild(a);
+    dt.textContent =  "Latest version:";
+    var child = latestVersion.field.nextElementSibling;
+    child.parentNode.insertBefore(dt, child);
+    child.parentNode.insertBefore(dd, child);
+    console.log(document.title);
+  }
+  expose("enhanceLatestVersions", enhanceLatestVersions);
+})();


### PR DESCRIPTION
since respec doesn't support more advanced handling of latest versions, here is an extension in the meantime. If we like it, we should adopt it across all webperf docs.

