### PR TITLE
Merge timeOrigin into Level 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 High Resolution Time
 =================
 
-High Resolution Time draft spec from webperf
+This specification defines an API that provides the time origin, and current time in sub-millisecond resolution, such that it is not subject to system clock skew or adjustments.
 
 For the latest version, see
   https://w3c.github.io/hr-time/
@@ -10,4 +10,4 @@ See also [Web performance README](https://github.com/w3c/web-performance/blob/gh
 
 Previous versions:
 
-* [Version 2](https://rawgit.com/w3c/hr-time/v2/index.html)
+* Level 1: https://www.w3.org/TR/hr-time-1/

--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,1 +1,1 @@
-index.html?specStatus=WD;shortName=hr-time-3;useExperimentalStyles=false respec
+index.html?specStatus=WD;shortName=hr-time-2;useExperimentalStyles=false respec

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <script class='remove'>
   var respecConfig = {
     shortName: "hr-time-2",
-    specStatus: "WD",
+    specStatus: "ED",
     edDraftURI: "https://w3c.github.io/hr-time/",
     editors: [{
       name: "Ilya Grigorik",

--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>High Resolution Time Level 3</title>
+  <title>High Resolution Time Level 2</title>
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class=
   'remove'>
   </script>
   <script class='remove'>
   var respecConfig = {
-    shortName: "hr-time-3",
-    specStatus: "ED",
+    shortName: "hr-time-2",
+    specStatus: "WD",
     edDraftURI: "https://w3c.github.io/hr-time/",
     editors: [{
       name: "Ilya Grigorik",
@@ -42,7 +42,7 @@
         href: 'https://github.com/w3c/hr-time/'
       }, {
         value: 'File a bug.',
-        href: 'https://github.com/w3c/hr-time/issues?q=milestone:%22Level%203%22'
+        href: 'https://github.com/w3c/hr-time/issues?q=milestone:%22Level%202%22'
       }, {
         value: 'Commit history.',
         href: 'https://github.com/w3c/hr-time/commits/gh-pages/index.html'
@@ -79,22 +79,31 @@
         date: 'March 2015'
       }
     },
-    wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/45211/status"
+    wgPatentURI: "https://www.w3.org/2004/01/pp-impl/45211/status"
   };
   </script>
 </head>
 <body>
   <section id="abstract">
-    <p>This specification defines an API that provides the current time in
-    sub-millisecond resolution and such that it is not subject to system clock
-    skew or adjustments.</p>
+    <p>This specification defines an API that provides the time origin, and current time in sub-millisecond resolution, such that it is not subject to system clock skew or adjustments.</p>
   </section>
   <section id="sotd">
-    <p>High Resolution Time Level 3 replaces the second version of High
-    Resolution Time [[HR-TIME-2]] and includes:</p>
+    <p>High Resolution Time Level 2 replaces the first version of High
+    Resolution Time [[HR-TIME]] and includes:</p>
     <ul>
+      <li>Defines a precise definition of <a>time origin</a> for the purpose of
+      all performance timeline related specifications;
+      </li>
       <li>Defines <a>performance.timeOrigin</a> attribute that provides the
       global time of the zero time of <a>time origin</a>;
+      </li>
+      <li>The base definition for the <a>Performance</a> interface, previously specified in [[PERFORMANCE-TIMELINE]],
+       is now moved to this specification and now includes support for the <a>Performance.now</a> method in Web Workers
+      [[WORKERS]];
+      </li>
+      <li>To mitigate <a href='#privacy-security'>cache attacks</a>, the
+      recommended minimum resolution of the Performance interface should be set
+      to 5 microseconds.
       </li>
     </ul>
   </section>

--- a/w3c.json
+++ b/w3c.json
@@ -1,6 +1,6 @@
 {
   "group":     45211
 , "contacts":  ["plehegar"]
-, "shortName": "navigation-timing"
+, "shortName": "hr-time"
 , "policy":    "open"
 }


### PR DESCRIPTION
Per discussion in [1], merging timeOrigin back into Level 2 and dropping
Level 3. We'll need to republish new CR.

[1]
https://lists.w3.org/Archives/Public/public-web-perf/2017Jul/0010.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/hr-time/l2.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/hr-time/0adb0b4...6813781.html)