### PR TITLE
Example currently broken in latest/published versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,15 +178,15 @@ onconnect = function(e) {
     var task_start = performance.now();
     result = runSomeWorkerTask();
     var task_end = performance.now();
-
-    // Send results and epoch-relative timestamps to another context
-    port.postMessage({
-       'task': 'Some worker task',
-       'start_time': task_start + performance.timeOrigin,
-       'end_time': task_end + performance.timeOrigin,
-       'result': result
-    });
   }
+
+  // Send results and epoch-relative timestamps to another context
+  port.postMessage({
+     'task': 'Some worker task',
+     'start_time': task_start + performance.timeOrigin,
+     'end_time': task_end + performance.timeOrigin,
+     'result': result
+  });
 }
 
 // ---- application.js ------------------------


### PR DESCRIPTION
The broken example causes the highlight script to completely screw it up.

So it currently looks like this:
![](https://ejd.pics/q56ka.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ericduran/hr-time/fix-broken-example.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/hr-time/179cbb1...ericduran:7833dc3.html)