### PR TITLE
Update spec to fix ambiguity around Time Origin definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,10 +238,10 @@ worker.port.onmessage = function (event) {
             browsing context is first created</a> if there is no previous
             document;
           </li>
-          <li>otherwise, the time of the user confirming the navigation if a
-          confirmation dialog is displayed during the <a href=
-          "https://www.w3.org/TR/html51/browsers.html#prompt-to-unload">
-            prompt to unload</a> algorithm;
+          <li>otherwise, the time of the user confirming the navigation during the previous
+          document's <a href="https://www.w3.org/TR/html51/browsers.html#prompt-to-unload">
+          prompt to unload algorithm</a>, if a previous document exists and if the
+          confirmation dialog was displayed;
           </li>
           <li>otherwise, the time of starting the <a href=
           "https://www.w3.org/TR/html51/browsers.html#navigated">navigation</a>


### PR DESCRIPTION
This PR addresses an ambiguity in the spec regarding the time origin during an `onunload` event.  Chart for reference:

![w3c-explanation](https://user-images.githubusercontent.com/5016978/33295843-dea641ea-d38c-11e7-92e6-db79f02ca43d.png)

At `Cu`, the spec as-written can be interpreted in one of two ways.  The time origin could either be `Cp` or `Bp` (or `Ap`, really).  The browser implementations use `Bp` as the time-origin.

The changes made to the spec disambiguates this case, as well as for measurements taken at `Bu` and `Au`, although the ambiguity has slightly different implications in those cases.  The new text indicates that the _previous document's_ prompt confirmation time should be used as the time origin, if available.  Otherwise it falls back to the next condition in the spec.

I'll be following up by adding tests in the https://github.com/w3c/web-platform-tests repo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/divmain/hr-time/pull/54.html" title="Last updated on Dec 11, 2017, 9:53 PM GMT (37b1339)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/54/eb78a11...divmain:37b1339.html" title="Last updated on Dec 11, 2017, 9:53 PM GMT (37b1339)">Diff</a>