### PR TITLE
WindowOrWorkerGlobalScope is a mixin

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@ interface Performance : EventTarget {
     <p>The <dfn>performance</dfn> attribute on the
     <code><dfn data-cite="!HTML#windoworworkerglobalscope-mixin">WindowOrWorkerGlobalScope</dfn></code> allows access to
     performance related attributes and methods from the [global object].</p>
-    <pre class='idl'>partial interface WindowOrWorkerGlobalScope {
+    <pre class='idl'>partial interface mixin WindowOrWorkerGlobalScope {
     [Replaceable]
     readonly    attribute Performance performance;
 };</pre>


### PR DESCRIPTION
...and so extensions should use [`partial interface mixin`](https://heycam.github.io/webidl/#partial-interface-mixin) rather than `interface mixin`.

See also https://github.com/whatwg/html/pull/3650


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/hr-time/pull/58.html" title="Last updated on Apr 27, 2018, 11:45 AM GMT (9edbcf7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/58/5220e4b...saschanaz:9edbcf7.html" title="Last updated on Apr 27, 2018, 11:45 AM GMT (9edbcf7)">Diff</a>