### PR TITLE
Remove issue number from note

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@ interface Performance : EventTarget {
       API does not significantly improve the accuracy or speed of such attacks,
       the recommended minimum resolution of the <a>DOMHighResTimeStamp</a> type
       should be inaccurate enough to prevent attacks.</p>
-      <div class="issue" data-number="56">
+      <div class="issue">
         Due to recent developments this may need to increase significantly, but the working group has not yet reached consensus on what the new recommend minimum value should be.
       </div>
       <p>Mitigating such timing side-channel attacks entirely is practically


### PR DESCRIPTION
ReSpec will not display a div of class="issue" when the issue number corresponds to a closed issue.
@plehegar @igrigorik @marcoscaceres PTAL. It will show up as "ISSUE 1" which I think is OK.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/hr-time/pull/59.html" title="Last updated on Jul 25, 2018, 7:33 PM GMT (bd9d459)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/59/6718e7b...npm1:bd9d459.html" title="Last updated on Jul 25, 2018, 7:33 PM GMT (bd9d459)">Diff</a>