### PR TITLE
chore: remove ReSpec format option, spec uses HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
     }],
     wg: "Web Performance Working Group",
     wgURI: "https://www.w3.org/webperf/",
-    format: "markdown",
     github: "https://github.com/w3c/hr-time/",
     caniuse: "high-resolution-time",
     localBiblio:  {


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/86.html" title="Last updated on Dec 30, 2019, 2:32 PM UTC (36d10ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/86/f56f3c3...36d10ac.html" title="Last updated on Dec 30, 2019, 2:32 PM UTC (36d10ac)">Diff</a>