### PR TITLE
Define 'relative high resolution time'

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,9 +250,21 @@
     recorded with respect to a global monotonic clock that is not subject to
     system and user clock adjustments, clock skew, and so on—see <a href=
     "#sec-monotonic-clock"></a>.</p>
-    <p>The <dfn data-export="">current high resolution time</dfn> is the high
-    resolution time from the <a>time origin</a> to the present time (typically
-    called "now").</p>
+    <p>
+    <div algorithm="relative high resolution time">
+      The <dfn data-export="">relative high resolution time</dfn> given |time|,
+       a {{DOMHighResTimeStamp}}, and |global|, a [=Realm/global object=],
+       runs the following steps:
+       <ul>
+         <li>Let |diff| be the difference between |time| and the |global|'s <a>time origin</a>.</li>
+         <li>Return |diff|.</li>
+       </ul>
+    </div>
+    </p>
+    <p>The <dfn data-export="">current high resolution time</dfn> returns the 
+    result of <a>relative high resolution time</a> where |time| is the 
+    present time and |global| is the <a data-cite="DOM#context-object">
+    context object</a>'s relevant [=Realm/global object=].</p>
   </section>
   <section id="sec-domhighrestimestamp">
     <h3>The <dfn data-export="">DOMHighResTimeStamp</dfn> typedef</h3>


### PR DESCRIPTION
Fixes https://github.com/w3c/hr-time/issues/87 by defining the concept of **relative high resolution time** .
Capable of being exported


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/igneel64/hr-time/pull/95.html" title="Last updated on Sep 16, 2020, 6:57 AM UTC (c376f39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/95/c2cb506...igneel64:c376f39.html" title="Last updated on Sep 16, 2020, 6:57 AM UTC (c376f39)">Diff</a>