### PR TITLE
Correct algorithm definition & 'current high resolution time' reform - Fixes #96

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,8 +252,8 @@
     "#sec-monotonic-clock"></a>.</p>
     <p>
     <div algorithm="relative high resolution time">
-      The <dfn data-export="">relative high resolution time</dfn> given |time|,
-       a {{DOMHighResTimeStamp}}, and |global|, a [=Realm/global object=],
+      The <dfn data-export="">relative high resolution time</dfn> given a 
+      {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|,
        runs the following steps:
        <ul>
          <li>Let |diff| be the difference between |time| and the |global|'s <a>time origin</a>.</li>
@@ -261,10 +261,10 @@
        </ul>
     </div>
     </p>
-    <p>The <dfn data-export="">current high resolution time</dfn> returns the 
-    result of <a>relative high resolution time</a> where |time| is the 
-    present time and |global| is the <a data-cite="DOM#context-object">
-    context object</a>'s relevant [=Realm/global object=].</p>
+    <p>The <dfn data-export="">current high resolution time</dfn> given a 
+    [=Realm/global object=] |current global| returns the result of <a>relative
+    high resolution time</a> where |time| is the present time and |global| is 
+    |current global|.</p>
   </section>
   <section id="sec-domhighrestimestamp">
     <h3>The <dfn data-export="">DOMHighResTimeStamp</dfn> typedef</h3>


### PR DESCRIPTION
- Fixes https://github.com/w3c/hr-time/issues/96

Definition based on https://infra.spec.whatwg.org/ spec & reform 'current high resolution time' to accept a global argument


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/igneel64/hr-time/pull/97.html" title="Last updated on Sep 22, 2020, 3:43 PM UTC (1f4f6cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/97/f563a5f...igneel64:1f4f6cd.html" title="Last updated on Sep 22, 2020, 3:43 PM UTC (1f4f6cd)">Diff</a>