### PR TITLE
Fix reference to unsafe shared time

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
     <p>The <dfn data-export="">current high resolution time</dfn> given a 
     [=/global object=] |current global| must run the following steps:
     <ul>
-      <li>Let |current time| be the |unsafe shared current time|.</li>
+      <li>Let |current time| be the [=unsafe shared current time=].</li>
       <li>Let |settings object| be |current global|'s [=relevant settings object=].</li>
       <li>Let |time resolution| be 100 microseconds, or a higher
         <a>implementation-defined</a> value.</li>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/hr-time/pull/109.html" title="Last updated on Mar 9, 2021, 8:52 AM UTC (a584bc3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/109/669b4f4...yoavweiss:a584bc3.html" title="Last updated on Mar 9, 2021, 8:52 AM UTC (a584bc3)">Diff</a>