### PR TITLE
Coarsen relative time

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,12 +311,9 @@
     </div>
     </p>
     <p>The <dfn data-export="">current high resolution time</dfn> given a 
-    [=/global object=] |current global| must run the following steps:
-    <ul>
-      <li>Let |current time| be the [=unsafe shared current time=].</li>
-      <li>Return the result of [=relative high resolution time=] given
-        |current time| and |current global|.</li>
-    </ul>
+    [=/global object=] |current global| must return the result of [=relative
+    high resolution time=] given [=unsafe shared current time=] and |current
+    global|.</p>
     <p>The <dfn data-export="">unsafe shared current time</dfn> must return the
     current value of the <a>shared monotonic clock</a>.
   </section>

--- a/index.html
+++ b/index.html
@@ -302,7 +302,9 @@
       {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|,
        runs the following steps:
        <ul>
-         <li>Let |diff| be the difference between |time| and the result of
+        <li>Let |coarse time| be the result of calling [=coarsen time=] with
+        |global| and |time|.</li>
+         <li>Let |diff| be the difference between |coarse time| and the result of
          calling [=get time origin timestamp=] with |global|.</li>
          <li>Return |diff|.</li>
        </ul>
@@ -312,10 +314,8 @@
     [=/global object=] |current global| must run the following steps:
     <ul>
       <li>Let |current time| be the [=unsafe shared current time=].</li>
-      <li>Let |coarse time| be the result of calling [=coarsen time=] with
-      |current global| and |current time|.</li>
       <li>Return the result of [=relative high resolution time=] given
-        |coarse time| and |current global|.</li>
+        |current time| and |current global|.</li>
     </ul>
     <p>The <dfn data-export="">unsafe shared current time</dfn> must return the
     current value of the <a>shared monotonic clock</a>.


### PR DESCRIPTION
Followup from #106, this makes sure that calling "relative HR time" is properly coarsened and safe to expose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/hr-time/pull/111.html" title="Last updated on Mar 10, 2021, 6:07 AM UTC (9c80718)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/111/29866ae...yoavweiss:9c80718.html" title="Last updated on Mar 10, 2021, 6:07 AM UTC (9c80718)">Diff</a>