### PR TITLE
Expose "relative high resolution coarse time"

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,15 +302,19 @@
     <div data-algorithm="relative high resolution time">
       The <dfn data-export="">relative high resolution time</dfn> given a
       {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|,
-       runs the following steps:
-       <ol>
+      is the result of the following steps:
+      <ol>
         <li>Let |coarse time| be the result of calling [=coarsen time=] with |time| and
         |global|'s [=relevant settings object=]'s
         [=environment settings object/cross-origin isolated capability=].</li>
-        <li>Let |diff| be the difference between |coarse time| and the result of
-        calling [=get time origin timestamp=] with |global|.</li>
-        <li>Return |diff|.</li>
+        <li>Return the [=relative high resolution coarse time=] for |coarse time| and
+        |global|.</li>
        </ol>
+
+      The <dfn data-export="">relative high resolution coarse time</dfn> given a
+      {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global object=] |global|,
+       is the difference between |coarseTime| and the result of
+        calling [=get time origin timestamp=] with |global|.</li>
     </div>
     </p>
     <p>The <dfn data-export="">current high resolution time</dfn> given a

--- a/index.html
+++ b/index.html
@@ -309,12 +309,12 @@
         [=environment settings object/cross-origin isolated capability=].</li>
         <li>Return the [=relative high resolution coarse time=] for |coarse time| and
         |global|.</li>
-       </ol>
+      </ol>
 
       The <dfn data-export="">relative high resolution coarse time</dfn> given a
       {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global object=] |global|,
        is the difference between |coarseTime| and the result of
-        calling [=get time origin timestamp=] with |global|.</li>
+        calling [=get time origin timestamp=] with |global|.
     </div>
     </p>
     <p>The <dfn data-export="">current high resolution time</dfn> given a


### PR DESCRIPTION
For resource-timing, we pre-coarsen the timestamps before
they can be converted to relative timestamps, so the inermediate
algorithm to calculate the relative timestamp from a pre-coarsened
absolulte timestamp is needed.

See https://github.com/w3c/resource-timing/pull/261


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/114.html" title="Last updated on Mar 25, 2021, 3:30 PM UTC (5cee397)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/114/4680852...5cee397.html" title="Last updated on Mar 25, 2021, 3:30 PM UTC (5cee397)">Diff</a>