### PR TITLE
Remove context object usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       },
     doJsonLd: true,
     xref: [ "html", "dom", "webidl", "ecma-262", "infra" ],
-    mdn: "hr-time-2",
+    mdn: "hr-time",
     highlightVars: true,
   };
   </script>
@@ -361,8 +361,8 @@
       <h3>`timeOrigin` attribute</h3>
       <p data-tests='timeOrigin.html, window-worker-timeOrigin.window.html'>The
       <dfn>timeOrigin</dfn> attribute MUST return the value returned by [=get
-      time origin timestamp=] for the <a>relevant global object</a> of the
-      [=context object=].</p>
+      time origin timestamp=] for the <a>relevant global object</a> of
+      [=this=].</p>
     </section>
     <section>
       <h3>`toJSON()` method</h3>


### PR DESCRIPTION
Replaces `context object` with `this`, and while at it also fixes the mdn reference.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/116.html" title="Last updated on May 6, 2021, 9:12 PM UTC (f796db1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/116/b6cbe47...f796db1.html" title="Last updated on May 6, 2021, 9:12 PM UTC (f796db1)">Diff</a>