### PR TITLE
chore: automatic tidy

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,20 @@
+name: Tidy document
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - gh-pages
+
+jobs:
+  tidy:
+    name: Tidy up
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install tidy-html5
+      - run: tidy -config tidyconfig.txt -o index.html index.html
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Tidy document using tidy-html5"
+          commit-message: "chore(index.html): tidy up document"
+          branch: html-tidy

--- a/index.html
+++ b/index.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>High Resolution Time</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" async class=
-  "remove"></script>
-  <script class="remove">
-  var respecConfig = {
+  <head>
+    <meta charset="utf-8">
+    <title>
+      High Resolution Time
+    </title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" async class=
+    "remove"></script>
+    <script class="remove">
+    var respecConfig = {
     shortName: "hr-time-3",
     specStatus: "ED",
     editors: [
@@ -48,103 +50,142 @@
     group: "webperf",
     xref: "web-platform",
     mdn: "hr-time",
-  };
-  </script>
-</head>
-<body>
-  <section id="abstract">
-    <p>This specification defines an API that provides the time origin, and
-    current time in sub-millisecond resolution, such that it is not subject to
-    system clock skew or adjustments.</p>
-  </section>
-  <section id="sotd"></section>
-  <section id="introduction" class="informative">
-    <h2>Introduction</h2>
-    <p>The ECMAScript Language specification [[ECMA-262]] defines the
-    <code><dfn data-no-export="" data-cite=
-    "ECMA-262#sec-date-objects">Date</dfn></code> object as a time value
-    representing time in milliseconds since 01 January, 1970 UTC. For most
-    purposes, this definition of time is sufficient as these values represent
-    time to millisecond precision for any instant that is within approximately
-    285,616 years from 01 January, 1970 UTC. The {{DOMTimeStamp}} is defined
-    similarly [[WEBIDL]].</p>
-    <p>In practice, these definitions of time are subject to both clock skew
-    and adjustment of the system clock. The value of time may not always be
-    monotonically increasing and subsequent values may either decrease or
-    remain the same.</p>
-    <p>For example, the following script may record a positive number, negative
-    number, or zero for computed <code>duration</code>:</p>
-    <pre class="example js">
+    highlightVars: true,
+    };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>
+        This specification defines an API that provides the time origin, and
+        current time in sub-millisecond resolution, such that it is not subject
+        to system clock skew or adjustments.
+      </p>
+    </section>
+    <section id="sotd"></section>
+    <section id="introduction" class="informative">
+      <h2>
+        Introduction
+      </h2>
+      <p>
+        The ECMAScript Language specification [[ECMA-262]] defines the
+        <code><dfn data-no-export="" data-cite=
+        "ECMA-262#sec-date-objects">Date</dfn></code> object as a time value
+        representing time in milliseconds since 01 January, 1970 UTC. For most
+        purposes, this definition of time is sufficient as these values
+        represent time to millisecond precision for any instant that is within
+        approximately 285,616 years from 01 January, 1970 UTC. The
+        {{DOMTimeStamp}} is defined similarly [[WEBIDL]].
+      </p>
+      <p>
+        In practice, these definitions of time are subject to both clock skew
+        and adjustment of the system clock. The value of time may not always be
+        monotonically increasing and subsequent values may either decrease or
+        remain the same.
+      </p>
+      <p>
+        For example, the following script may record a positive number,
+        negative number, or zero for computed <code>duration</code>:
+      </p>
+      <pre class="example js">
+&gt;&gt;&gt;&gt;&gt;&gt;&gt; 5b1777c (use indent: yes)
       var mark_start = Date.now();
       doTask(); // Some task
       var duration = Date.now() - mark_start;
     </pre>
-    <p>For certain tasks this definition of time may not be sufficient as
-    it:</p>
-    <ul>
-      <li>Does not have a stable monotonic clock, and as a result, it is
-      subject to system clock skew.</li>
-      <li>Does not provide sub-millisecond time resolution.</li>
-    </ul>
-    <p>This specification does not propose changing the behavior of
-    <code><dfn data-no-export="" data-cite=
-    "ecma-262#sec-date.now">Date.now()</dfn></code> [[ECMA-262]] as it is
-    genuinely useful in determining the current value of the calendar time and
-    has a long history of usage. The {{DOMHighResTimeStamp}} type,
-    {{Performance}}.{{Performance/now()}} method, and
-    {{Performance}}.{{Performance/timeOrigin}} attributes of the
-    {{Performance}} interface resolve the above issues by providing
-    monotonically increasing time values with sub-millisecond resolution.</p>
-    <p class="note">Providing sub-millisecond resolution is not a mandatory
-    part of this specification. Implementations may choose to limit the timer
-    resolution they expose for privacy and security reasons, and not expose
-    sub-millisecond timers. Use-cases that rely on sub-millisecond resolution
-    may not be satisfied when that happens.</p>
-    <section id="use-cases" class="informative">
-      <h3>Use-cases</h3>
-      <p>This specification defines a few different capabilities: it provides
-      timestamps based on a stable, monotonic clock, comparable across
-      contexts, with potential sub-millisecond resolution.</p>
-      <p>The need for a stable monotonic clock when talking about performance
-      measurements stems from the fact that unrelated clock skew can distort
-      measurements and render them useless. For example, when attempting to
-      accurately measure the elapsed time of navigating to a Document, fetching
-      of resources or execution of script, a monotonically increasing clock
-      with sub-millisecond resolution is desired.</p>
-      <p>Comparing timestamps between contexts is essential e.g. when
-      synchronizing work between a {{Worker}} and the main thread or when
-      instrumenting such work in order to create a unified view of the event
-      timeline.</p>
-      <p>Finally, the need for sub-millisecond timers revolves around the
-      following use-cases:</p>
+      <p>
+        For certain tasks this definition of time may not be sufficient as it:
+      </p>
       <ul>
-        <li>Ability to schedule work in sub-millisecond intervals. That is
-        particularly important on the main thread, where work can interfere
-        with frame rendering which needs to happen in short and regular
-        intervals, to avoid user-visible jank.</li>
-        <li>When calculating the frame rate of a script-based animation,
-        developers will need sub-millisecond resolution in order to determine
-        if an animation is drawing at 60 FPS. Without sub-millisecond
-        resolution, a developer can only determine if an animation is drawing
-        at 58.8 FPS (1000ms / 16) or 62.5 FPS (1000ms / 17).</li>
-        <li>When collecting in-the-wild measurements of JS code (e.g. using
-        User-Timing), developers may be interested in gathering
-        sub-milliseconds timing of their functions, to catch regressions
-        early.</li>
-        <li>When attempting to cue audio to a specific point in an animation or
-        ensure that the audio and animation are perfectly synchronized,
-        developers will need to accurately measure the amount of time
-        elapsed.</li>
+        <li>Does not have a stable monotonic clock, and as a result, it is
+        subject to system clock skew.
+        </li>
+        <li>Does not provide sub-millisecond time resolution.
+        </li>
       </ul>
-    </section>
-    <section id="examples" class="informative">
-      <h3>Examples</h3>
-      <p>A developer may wish to construct a timeline of their entire
-      application, including events from {{Worker}} or {{SharedWorker}}, which
-      have different <a>time origin</a>s. To display such events on the same
-      timeline, the application can translate the {{DOMHighResTimeStamp}}s with
-      the help of the {{Performance}}.{{Performance/timeOrigin}} attribute.</p>
-      <pre class="example js">
+      <p>
+        This specification does not propose changing the behavior of
+        <code><dfn data-no-export="" data-cite=
+        "ecma-262#sec-date.now">Date.now()</dfn></code> [[ECMA-262]] as it is
+        genuinely useful in determining the current value of the calendar time
+        and has a long history of usage. The {{DOMHighResTimeStamp}} type,
+        {{Performance}}.{{Performance/now()}} method, and
+        {{Performance}}.{{Performance/timeOrigin}} attributes of the
+        {{Performance}} interface resolve the above issues by providing
+        monotonically increasing time values with sub-millisecond resolution.
+      </p>
+      <p class="note">
+        Providing sub-millisecond resolution is not a mandatory part of this
+        specification. Implementations may choose to limit the timer resolution
+        they expose for privacy and security reasons, and not expose
+        sub-millisecond timers. Use-cases that rely on sub-millisecond
+        resolution may not be satisfied when that happens.
+      </p>
+      <section id="use-cases" class="informative">
+        <h3>
+          Use-cases
+        </h3>
+        <p>
+          This specification defines a few different capabilities: it provides
+          timestamps based on a stable, monotonic clock, comparable across
+          contexts, with potential sub-millisecond resolution.
+        </p>
+        <p>
+          The need for a stable monotonic clock when talking about performance
+          measurements stems from the fact that unrelated clock skew can
+          distort measurements and render them useless. For example, when
+          attempting to accurately measure the elapsed time of navigating to a
+          Document, fetching of resources or execution of script, a
+          monotonically increasing clock with sub-millisecond resolution is
+          desired.
+        </p>
+        <p>
+          Comparing timestamps between contexts is essential e.g. when
+          synchronizing work between a {{Worker}} and the main thread or when
+          instrumenting such work in order to create a unified view of the
+          event timeline.
+        </p>
+        <p>
+          Finally, the need for sub-millisecond timers revolves around the
+          following use-cases:
+        </p>
+        <ul>
+          <li>Ability to schedule work in sub-millisecond intervals. That is
+          particularly important on the main thread, where work can interfere
+          with frame rendering which needs to happen in short and regular
+          intervals, to avoid user-visible jank.
+          </li>
+          <li>When calculating the frame rate of a script-based animation,
+          developers will need sub-millisecond resolution in order to determine
+          if an animation is drawing at 60 FPS. Without sub-millisecond
+          resolution, a developer can only determine if an animation is drawing
+          at 58.8 FPS (1000ms / 16) or 62.5 FPS (1000ms / 17).
+          </li>
+          <li>When collecting in-the-wild measurements of JS code (e.g. using
+          User-Timing), developers may be interested in gathering
+          sub-milliseconds timing of their functions, to catch regressions
+          early.
+          </li>
+          <li>When attempting to cue audio to a specific point in an animation
+          or ensure that the audio and animation are perfectly synchronized,
+          developers will need to accurately measure the amount of time
+          elapsed.
+          </li>
+        </ul>
+      </section>
+      <section id="examples" class="informative">
+        <h3>
+          Examples
+        </h3>
+        <p>
+          A developer may wish to construct a timeline of their entire
+          application, including events from {{Worker}} or {{SharedWorker}},
+          which have different <a>time origin</a>s. To display such events on
+          the same timeline, the application can translate the
+          {{DOMHighResTimeStamp}}s with the help of the
+          {{Performance}}.{{Performance/timeOrigin}} attribute.
+        </p>
+        <pre class="example js">
         // ---- worker.js -----------------------------
         // Shared worker script
         onconnect = function(e) {
@@ -190,124 +231,154 @@
           reportEventToAnalytics(msg);
         }
       </pre>
+      </section>
     </section>
-  </section>
-  <section id="sec-time-origin">
-    <h3>Time Origin</h3>
-    <p>The <dfn data-export="">time origin</dfn> is the time value from which
-    time is measured:</p>
-    <ul>
-      <li>If the [=Realm/global object=] is a {{Window}} object, the <a>time
-      origin</a> MUST be equal to:
-        <ul>
-          <li>the time when the <a data-cite=
-          "HTML/browsers.html#creating-a-new-browsing-context">browsing context
-          is first created</a> if there is no previous document;
-          </li>
-          <li>otherwise, the time of the user confirming the navigation during
-          the previous document's <a data-cite=
-          "HTML/browsing-the-web.html#prompt-to-unload-a-document">prompt to
-          unload algorithm</a>, if a previous document exists and if the
-          confirmation dialog was displayed;
-          </li>
-          <li>otherwise, the time of starting the <a data-lt=
-          "navigate">navigation</a> responsible for loading the <a data-lt=
-          "associated document">Window object's newest Document object</a>.
-          </li>
-        </ul>
-      </li>
-      <li>If the [=Realm/global object=] is a {{WorkerGlobalScope}} object, the
-      <a>time origin</a> MUST be equal to the <a>official moment of
-      creation</a> of the worker.
-      </li>
-      <li>Otherwise, the <a>time origin</a> is undefined.
-      </li>
-    </ul>
-    <p>To <dfn>get time origin timestamp</dfn>, given a [=Realm/global object=]
-    |global|, runs the following steps:</p>
-    <ol>
-      <li>Assert: <var>global</var>'s <a>time origin</a> is not undefined.
-      </li>
-      <li>Let <var>t1</var> be the {{DOMHighResTimeStamp}} representing the
-      high resolution time at which the <a>shared monotonic clock</a> is zero.
-      </li>
-      <li>Let <var>t2</var> be the {{DOMHighResTimeStamp}} representing the
-      high resolution time value of the <a>shared monotonic clock</a> at <var>
-        global</var>'s <a>time origin</a>.
-      </li>
-      <li>Let |total| be the sum of <var>t1</var> and <var>t2</var>.</li>
-      <li>Return the result of calling [=coarsen time=] with |total| and
-      |global|'s [=relevant settings object=]'s [=environment settings
-      object/cross-origin isolated capability=].</li>
-    </ol>
-    <p class="note">The value returned by [=get time origin timestamp=] is the
-    high resolution time value at which <a>time origin</a> is zero. It may
-    differ from the value returned by <a>Date.now()</a> executed at "zero
-    time", because the former is recorded with respect to a <a>shared monotonic
-    clock</a> that is not subject to system and user clock adjustments, clock
-    skew, and so on — see <a href="#sec-monotonic-clock"></a>.</p>
-    <div data-algorithm="coarsen time">
-      The <dfn data-export="">coarsen time</dfn> algorithm, given a
-      {{DOMHighResTimeStamp}} |timestamp| and an optional boolean
-      |crossOriginIsolatedCapability| (default false), runs the following
-      steps:
+    <section id="sec-time-origin">
+      <h3>
+        Time Origin
+      </h3>
+      <p>
+        The <dfn data-export="">time origin</dfn> is the time value from which
+        time is measured:
+      </p>
+      <ul>
+        <li>If the [=Realm/global object=] is a {{Window}} object, the <a>time
+        origin</a> MUST be equal to:
+          <ul>
+            <li>the time when the <a data-cite=
+            "HTML/browsers.html#creating-a-new-browsing-context">browsing
+            context is first created</a> if there is no previous document;
+            </li>
+            <li>otherwise, the time of the user confirming the navigation
+            during the previous document's <a data-cite=
+            "HTML/browsing-the-web.html#prompt-to-unload-a-document">prompt to
+            unload algorithm</a>, if a previous document exists and if the
+            confirmation dialog was displayed;
+            </li>
+            <li>otherwise, the time of starting the <a data-lt=
+            "navigate">navigation</a> responsible for loading the <a data-lt=
+            "associated document">Window object's newest Document object</a>.
+            </li>
+          </ul>
+        </li>
+        <li>If the [=Realm/global object=] is a {{WorkerGlobalScope}} object,
+        the <a>time origin</a> MUST be equal to the <a>official moment of
+        creation</a> of the worker.
+        </li>
+        <li>Otherwise, the <a>time origin</a> is undefined.
+        </li>
+      </ul>
+      <p>
+        To <dfn>get time origin timestamp</dfn>, given a [=Realm/global
+        object=] |global|, runs the following steps:
+      </p>
       <ol>
-        <li>Let |time resolution| be 100 microseconds, or a higher
-        <a>implementation-defined</a> value.
+        <li>Assert: <var>global</var>'s <a>time origin</a> is not undefined.
         </li>
-        <li>If |crossOriginIsolatedCapability| is true, set |time resolution|
-        to be 5 microseconds, or a higher <a>implementation-defined</a> value.
+        <li>Let <var>t1</var> be the {{DOMHighResTimeStamp}} representing the
+        high resolution time at which the <a>shared monotonic clock</a> is
+        zero.
         </li>
-        <li>In an <a>implementation-defined</a> manner, coarsen and potentially
-        jitter |timestamp| such that its resolution will not exceed |time
-        resolution|.
+        <li>Let <var>t2</var> be the {{DOMHighResTimeStamp}} representing the
+        high resolution time value of the <a>shared monotonic clock</a> at
+        <var>global</var>'s <a>time origin</a>.
         </li>
-        <li>Return |timestamp|.</li>
+        <li>Let |total| be the sum of <var>t1</var> and <var>t2</var>.
+        </li>
+        <li>Return the result of calling [=coarsen time=] with |total| and
+        |global|'s [=relevant settings object=]'s [=environment settings
+        object/cross-origin isolated capability=].
+        </li>
       </ol>
-    </div>
-    <div data-algorithm="relative high resolution time">
-      The <dfn data-export="">relative high resolution time</dfn> given a
-      {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|, is
-      the result of the following steps:
-      <ol>
-        <li>Let |coarse time| be the result of calling [=coarsen time=] with
-        |time| and |global|'s [=relevant settings object=]'s [=environment
-        settings object/cross-origin isolated capability=].</li>
-        <li>Return the [=relative high resolution coarse time=] for |coarse
-        time| and |global|.</li>
-      </ol>The <dfn data-export="">relative high resolution coarse time</dfn>
-      given a {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global
-      object=] |global|, is the difference between |coarseTime| and the result
-      of calling [=get time origin timestamp=] with |global|.
-    </div>
-    <p>The <dfn data-export="">current high resolution time</dfn> given a
-    [=/global object=] |current global| must return the result of [=relative
-    high resolution time=] given [=unsafe shared current time=] and |current
-    global|.</p>
-    <p>The <dfn data-export="">coarsened shared current time</dfn> given an
-    optional boolean |crossOriginIsolatedCapability| (default false), must
-    return the result of calling [=coarsen time=] with the [=unsafe shared
-    current time=] and |crossOriginIsolatedCapability|.</p>
-    <p>The <dfn data-export="">unsafe shared current time</dfn> must return the
-    current value of the <a>shared monotonic clock</a>.</p>
-  </section>
-  <section id="sec-domhighrestimestamp">
-    <h3>The <dfn data-export="">DOMHighResTimeStamp</dfn> typedef</h3>
-    <p>The {{DOMHighResTimeStamp}} type is used to store a time value in
-    milliseconds, measured relative from the <a>time origin</a>, <a>shared
-    monotonic clock</a>, or a time value that represents a duration between two
-    {{DOMHighResTimeStamp}}s.</p>
-    <pre class="idl">
+      <p class="note">
+        The value returned by [=get time origin timestamp=] is the high
+        resolution time value at which <a>time origin</a> is zero. It may
+        differ from the value returned by <a>Date.now()</a> executed at "zero
+        time", because the former is recorded with respect to a <a>shared
+        monotonic clock</a> that is not subject to system and user clock
+        adjustments, clock skew, and so on — see <a href=
+        "#sec-monotonic-clock"></a>.
+      </p>
+      <div data-algorithm="coarsen time">
+        The <dfn data-export="">coarsen time</dfn> algorithm, given a
+        {{DOMHighResTimeStamp}} |timestamp| and an optional boolean
+        |crossOriginIsolatedCapability| (default false), runs the following
+        steps:
+        <ol>
+          <li>Let |time resolution| be 100 microseconds, or a higher
+          <a>implementation-defined</a> value.
+          </li>
+          <li>If |crossOriginIsolatedCapability| is true, set |time resolution|
+          to be 5 microseconds, or a higher <a>implementation-defined</a>
+          value.
+          </li>
+          <li>In an <a>implementation-defined</a> manner, coarsen and
+          potentially jitter |timestamp| such that its resolution will not
+          exceed |time resolution|.
+          </li>
+          <li>Return |timestamp|.
+          </li>
+        </ol>
+      </div>
+      <div data-algorithm="relative high resolution time">
+        The <dfn data-export="">relative high resolution time</dfn> given a
+        {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|,
+        is the result of the following steps:
+        <ol>
+          <li>Let |coarse time| be the result of calling [=coarsen time=] with
+          |time| and |global|'s [=relevant settings object=]'s [=environment
+          settings object/cross-origin isolated capability=].
+          </li>
+          <li>Return the [=relative high resolution coarse time=] for |coarse
+          time| and |global|.
+          </li>
+        </ol>The <dfn data-export="">relative high resolution coarse time</dfn>
+        given a {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global
+        object=] |global|, is the difference between |coarseTime| and the
+        result of calling [=get time origin timestamp=] with |global|.
+      </div>
+      <p>
+        The <dfn data-export="">current high resolution time</dfn> given a
+        [=/global object=] |current global| must return the result of
+        [=relative high resolution time=] given [=unsafe shared current time=]
+        and |current global|.
+      </p>
+      <p>
+        The <dfn data-export="">coarsened shared current time</dfn> given an
+        optional boolean |crossOriginIsolatedCapability| (default false), must
+        return the result of calling [=coarsen time=] with the [=unsafe shared
+        current time=] and |crossOriginIsolatedCapability|.
+      </p>
+      <p>
+        The <dfn data-export="">unsafe shared current time</dfn> must return
+        the current value of the <a>shared monotonic clock</a>.
+      </p>
+    </section>
+    <section id="sec-domhighrestimestamp">
+      <h3>
+        The <dfn data-export="">DOMHighResTimeStamp</dfn> typedef
+      </h3>
+      <p>
+        The {{DOMHighResTimeStamp}} type is used to store a time value in
+        milliseconds, measured relative from the <a>time origin</a>, <a>shared
+        monotonic clock</a>, or a time value that represents a duration between
+        two {{DOMHighResTimeStamp}}s.
+      </p>
+      <pre class="idl">
       typedef double DOMHighResTimeStamp;
     </pre>
-    <p>A {{DOMHighResTimeStamp}} SHOULD represent a time in milliseconds
-    accurate enough to allow measurement while preventing timing attacks - see
-    <a href="#clock-resolution"></a> for additional considerations.</p>
-  </section>
-  <section id="sec-performance" data-dfn-for="Performance" data-link-for=
-  "Performance">
-    <h3>The <dfn>Performance</dfn> interface</h3>
-    <pre class="idl">
+      <p>
+        A {{DOMHighResTimeStamp}} SHOULD represent a time in milliseconds
+        accurate enough to allow measurement while preventing timing attacks -
+        see <a href="#clock-resolution"></a> for additional considerations.
+      </p>
+    </section>
+    <section id="sec-performance" data-dfn-for="Performance" data-link-for=
+    "Performance">
+      <h3>
+        The <dfn>Performance</dfn> interface
+      </h3>
+      <pre class="idl">
       [Exposed=(Window,Worker)]
       interface Performance : EventTarget {
           DOMHighResTimeStamp now();
@@ -315,177 +386,246 @@
           [Default] object toJSON();
       };
     </pre>
-    <section>
-      <h3>`now()` method</h3>
-      <p data-tests="basic.any.html, basic.any.worker.html">The
-      <dfn>now()</dfn> method MUST return the <a>current high resolution
-      time</a>.</p>
+      <section>
+        <h3>
+          `now()` method
+        </h3>
+        <p data-tests="basic.any.html, basic.any.worker.html">
+          The <dfn>now()</dfn> method MUST return the <a>current high
+          resolution time</a>.
+        </p>
+      </section>
+      <section>
+        <h3>
+          `timeOrigin` attribute
+        </h3>
+        <p data-tests="timeOrigin.html, window-worker-timeOrigin.window.html">
+          The <dfn>timeOrigin</dfn> attribute MUST return the value returned by
+          [=get time origin timestamp=] for the <a>relevant global object</a>
+          of [=this=].
+        </p>
+      </section>
+      <section>
+        <h3>
+          `toJSON()` method
+        </h3>
+        <p data-tests="performance-tojson.html">
+          When <dfn>toJSON()</dfn> is called, run [[WEBIDL]]'s <a>default
+          toJSON steps</a>.
+        </p>
+      </section>
     </section>
     <section>
-      <h3>`timeOrigin` attribute</h3>
-      <p data-tests="timeOrigin.html, window-worker-timeOrigin.window.html">The
-      <dfn>timeOrigin</dfn> attribute MUST return the value returned by [=get
-      time origin timestamp=] for the <a>relevant global object</a> of
-      [=this=].</p>
-    </section>
-    <section>
-      <h3>`toJSON()` method</h3>
-      <p data-tests="performance-tojson.html">When <dfn>toJSON()</dfn> is
-      called, run [[WEBIDL]]'s <a>default toJSON steps</a>.</p>
-    </section>
-  </section>
-  <section>
-    <h2>Extensions to `WindowOrWorkerGlobalScope` mixin</h2>
-    <section data-dfn-for="WindowOrWorkerGlobalScope" data-link-for=
-    "WindowOrWorkerGlobalScope">
-      <h3>The <code>performance</code> attribute</h3>
-      <p>The <dfn>performance</dfn> attribute on the interface mixin
-      {{WindowOrWorkerGlobalScope}} allows access to performance related
-      attributes and methods from the [=Realm/global object=].</p>
-      <pre class="idl">
+      <h2>
+        Extensions to `WindowOrWorkerGlobalScope` mixin
+      </h2>
+      <section data-dfn-for="WindowOrWorkerGlobalScope" data-link-for=
+      "WindowOrWorkerGlobalScope">
+        <h3>
+          The <code>performance</code> attribute
+        </h3>
+        <p>
+          The <dfn>performance</dfn> attribute on the interface mixin
+          {{WindowOrWorkerGlobalScope}} allows access to performance related
+          attributes and methods from the [=Realm/global object=].
+        </p>
+        <pre class="idl">
       partial interface mixin WindowOrWorkerGlobalScope {
         [Replaceable] readonly attribute Performance performance;
       };
   </pre>
+      </section>
     </section>
-  </section>
-  <section id="sec-monotonic-clock">
-    <h3>Monotonic Clock</h3>
-    <p data-tests="monotonic-clock.any.html, monotonic-clock.any.worker.html">
-    The time values returned when calling the {{Performance/now()}} method on
-    {{Performance}} objects with the same <a>time origin</a> MUST use the same
-    <dfn data-export="">monotonic clock</dfn> that is monotonically increasing
-    and not subject to system clock adjustments or system clock skew. The
-    difference between any two chronologically recorded time values returned
-    from the {{Performance/now()}} method MUST never be negative if the two
-    time values have the same <a>time origin</a>.</p>
-    <p data-tests="test_cross_frame_start.html">The time values returned when
-    getting {{Performance}}.{{Performance/timeOrigin}} MUST use the same
-    <dfn>shared monotonic clock</dfn> that is shared by <a>time origin</a>s, is
-    monotonically increasing and not subject to system clock adjustments or
-    system clock skew, and whose reference point is the [[ECMA-262]]
-    <dfn data-no-export="" data-cite=
-    "ECMA-262#sec-time-values-and-time-range">time</dfn> definition - see
-    [[[#sec-privacy-security]]].</p>
-    <p class="note">The user agent can reset its <a>shared monotonic clock</a>
-    across browser restarts, or whenever starting an isolated browsing
-    session—e.g. incognito or similar browsing mode. As a result, developers
-    should not use shared timestamps as absolute time that holds its monotonic
-    properties across all past, present, and future contexts; in practice, the
-    monotonic properties only apply for contexts that can reach each other by
-    exchanging messages via one of the provided messaging mechanisms - e.g.
-    `postMessage`, `BroadcastChannel`, etc.</p>
-    <p class="note">In certain scenarios (e.g. when a tab is backgrounded), the
-    user agent may choose to throttle timers and periodic callbacks run in that
-    context or even freeze them entirely. Any such throttling should not affect
-    the resolution or accuracy of the time returned by the monotonic clock.</p>
-  </section>
-  <section id="sec-privacy-security">
-    <h3>Privacy and Security</h3>
-    <section>
-      <h3>Clock resolution</h3>
-      <p>Access to accurate timing information, both for measurement and
-      scheduling purposes, is a common requirement for many applications. For
-      example, coordinating animations, sound, and other activity on the page
-      requires access to high-resolution time to provide a good user
-      experience. Similarly, measurement enables developers to track the
-      performance of critical code components, detect regressions, and so
-      on.</p>
-      <p>However, access to the same accurate timing information can sometimes
-      be also used for malicious purposes by an attacker to guess and infer
-      data that they can't see or access otherwise. For example, cache attacks,
-      statistical fingerprinting and micro-architectural attacks are a privacy
-      and security concern where a malicious web site may use high resolution
-      timing data of various browser or application-initiated operations to
-      differentiate between subset of users, identify a particular user or
-      reveal unrelated but same-process user data - see [[?CACHE-ATTACKS]] and
-      [[SPECTRE]] for more background.</p>
-      <p data-tests="timing-attack.html">This specification defines an API that
-      provides sub-millisecond time resolution, which is more accurate than the
-      previously available millisecond resolution exposed by {{DOMTimeStamp}}.
-      However, even without this new API an attacker may be able to obtain
-      high-resolution estimates through repeat execution and statistical
-      analysis.</p>
-      <p>To ensure that the new API does not significantly improve the accuracy
-      or speed of such attacks, the minimum resolution of the
-      {{DOMHighResTimeStamp}} type should be inaccurate enough to prevent
-      attacks.</p>
-      <p>Where necessary, the user agent should set higher resolution values to
-      |time resolution| in [=coarsen time=]'s processing model, to address
-      privacy and security concerns due to architecture or software
-      constraints, or other considerations.</p>
-      <p>In order to mitigate such attacks user agents may deploy any technique
-      they deem necessary. Deployment of those techniques may vary based on the
-      browser's architecture, the user's device, the content and its ability to
-      maliciously read cross-origin data, or other practical
-      considerations.</p>
-      <p>These techniques may include:</p>
-      <ul>
-        <li>Resolution reduction.</li>
-        <li>Added jitter.</li>
-        <li>Abuse detection and/or API call throttling.</li>
-      </ul>
-      <p>Mitigating such timing side-channel attacks entirely is practically
-      impossible: either all operations would have to execute in a time that
-      does not vary based on the value of any confidential information, or the
-      application would need to be isolated from any time-related primitives
-      (clock, timers, counters, etc). Neither is practical due to the
-      associated complexity for the browser and application developers and the
-      associated negative effects on performance and responsiveness of
-      applications.</p>
-      <div class="note">
-        Clock resolution is an unsolved and evolving area of research, with no
-        existing industry consensus or definitive set of recommendations that
-        applies to all browsers. To track the discussion, refer to <a href=
-        "https://github.com/w3c/hr-time/issues/79">Issue 79</a>.
-      </div>
+    <section id="sec-monotonic-clock">
+      <h3>
+        Monotonic Clock
+      </h3>
+      <p data-tests=
+      "monotonic-clock.any.html, monotonic-clock.any.worker.html">
+        The time values returned when calling the {{Performance/now()}} method
+        on {{Performance}} objects with the same <a>time origin</a> MUST use
+        the same <dfn data-export="">monotonic clock</dfn> that is
+        monotonically increasing and not subject to system clock adjustments or
+        system clock skew. The difference between any two chronologically
+        recorded time values returned from the {{Performance/now()}} method
+        MUST never be negative if the two time values have the same <a>time
+        origin</a>.
+      </p>
+      <p data-tests="test_cross_frame_start.html">
+        The time values returned when getting
+        {{Performance}}.{{Performance/timeOrigin}} MUST use the same
+        <dfn>shared monotonic clock</dfn> that is shared by <a>time
+        origin</a>s, is monotonically increasing and not subject to system
+        clock adjustments or system clock skew, and whose reference point is
+        the [[ECMA-262]] <dfn data-no-export="" data-cite=
+        "ECMA-262#sec-time-values-and-time-range">time</dfn> definition - see
+        [[[#sec-privacy-security]]].
+      </p>
+      <p class="note">
+        The user agent can reset its <a>shared monotonic clock</a> across
+        browser restarts, or whenever starting an isolated browsing
+        session—e.g. incognito or similar browsing mode. As a result,
+        developers should not use shared timestamps as absolute time that holds
+        its monotonic properties across all past, present, and future contexts;
+        in practice, the monotonic properties only apply for contexts that can
+        reach each other by exchanging messages via one of the provided
+        messaging mechanisms - e.g. `postMessage`, `BroadcastChannel`, etc.
+      </p>
+      <p class="note">
+        In certain scenarios (e.g. when a tab is backgrounded), the user agent
+        may choose to throttle timers and periodic callbacks run in that
+        context or even freeze them entirely. Any such throttling should not
+        affect the resolution or accuracy of the time returned by the monotonic
+        clock.
+      </p>
     </section>
-    <section>
-      <h3>Clock drift</h3>
-      <p>This specification also defines an API that provides sub-millisecond
-      time resolution of the zero time of the time origin, which requires and
-      exposes a <a>shared monotonic clock</a> to the application, and that must
-      be shared across all the browser contexts. The <a>shared monotonic
-      clock</a> does not need to be tied to physical time, but is recommended
-      to be set with respect to the [[ECMA-262]] definition of <a>time</a> to
-      avoid exposing new fingerprint entropy about the user — e.g. this time
-      can already be easily obtained by the application, whereas exposing a new
-      logical clock provides new information.</p>
-      <p>However, even with the above mechanism in place, the <a>shared
-      monotonic clock</a> may provide additional <a href=
-      "https://en.wikipedia.org/wiki/Clock_drift">clock drift</a> resolution.
-      Today, the application can timestamp the time-of-day and monotonic time
-      values (via <a>Date.now()</a> and {{Performance/now()}}) at multiple
-      points within the same context and observe drift between them—e.g. due to
-      automatic or user clock adjustments. With the {{Performance/timeOrigin}}
-      attribute, the attacker can also compare the time at which <a>time
-      origin</a> is zero, as reported by the <a>shared monotonic clock</a>,
-      against the current time-of-day estimate of when it is zero (i.e. the
-      difference between `Date.now() - performance.now()` and
-      `performance.timeOrigin`) and potentially observe clock drift between
-      these clocks over a longer time period.</p>
-      <p>In practice, the same time drift can be observed by an application
-      across multiple navigations: the application can record the logical time
-      in each context and use a client or server time synchronization mechanism
-      to infer changes in the user's clock. Similarly, lower-layer mechanisms
-      such as TCP timestamps may reveal the same high-resolution information to
-      the server without the need for multiple visits. As such, the information
-      provided by this API should not expose any significant or previously
-      unavailable entropy about the user.</p>
+    <section id="sec-privacy-security">
+      <h3>
+        Privacy and Security
+      </h3>
+      <section>
+        <h3>
+          Clock resolution
+        </h3>
+        <p>
+          Access to accurate timing information, both for measurement and
+          scheduling purposes, is a common requirement for many applications.
+          For example, coordinating animations, sound, and other activity on
+          the page requires access to high-resolution time to provide a good
+          user experience. Similarly, measurement enables developers to track
+          the performance of critical code components, detect regressions, and
+          so on.
+        </p>
+        <p>
+          However, access to the same accurate timing information can sometimes
+          be also used for malicious purposes by an attacker to guess and infer
+          data that they can't see or access otherwise. For example, cache
+          attacks, statistical fingerprinting and micro-architectural attacks
+          are a privacy and security concern where a malicious web site may use
+          high resolution timing data of various browser or
+          application-initiated operations to differentiate between subset of
+          users, identify a particular user or reveal unrelated but
+          same-process user data - see [[?CACHE-ATTACKS]] and [[SPECTRE]] for
+          more background.
+        </p>
+        <p data-tests="timing-attack.html">
+          This specification defines an API that provides sub-millisecond time
+          resolution, which is more accurate than the previously available
+          millisecond resolution exposed by {{DOMTimeStamp}}. However, even
+          without this new API an attacker may be able to obtain
+          high-resolution estimates through repeat execution and statistical
+          analysis.
+        </p>
+        <p>
+          To ensure that the new API does not significantly improve the
+          accuracy or speed of such attacks, the minimum resolution of the
+          {{DOMHighResTimeStamp}} type should be inaccurate enough to prevent
+          attacks.
+        </p>
+        <p>
+          Where necessary, the user agent should set higher resolution values
+          to |time resolution| in [=coarsen time=]'s processing model, to
+          address privacy and security concerns due to architecture or software
+          constraints, or other considerations.
+        </p>
+        <p>
+          In order to mitigate such attacks user agents may deploy any
+          technique they deem necessary. Deployment of those techniques may
+          vary based on the browser's architecture, the user's device, the
+          content and its ability to maliciously read cross-origin data, or
+          other practical considerations.
+        </p>
+        <p>
+          These techniques may include:
+        </p>
+        <ul>
+          <li>Resolution reduction.
+          </li>
+          <li>Added jitter.
+          </li>
+          <li>Abuse detection and/or API call throttling.
+          </li>
+        </ul>
+        <p>
+          Mitigating such timing side-channel attacks entirely is practically
+          impossible: either all operations would have to execute in a time
+          that does not vary based on the value of any confidential
+          information, or the application would need to be isolated from any
+          time-related primitives (clock, timers, counters, etc). Neither is
+          practical due to the associated complexity for the browser and
+          application developers and the associated negative effects on
+          performance and responsiveness of applications.
+        </p>
+        <div class="note">
+          Clock resolution is an unsolved and evolving area of research, with
+          no existing industry consensus or definitive set of recommendations
+          that applies to all browsers. To track the discussion, refer to
+          <a href="https://github.com/w3c/hr-time/issues/79">Issue 79</a>.
+        </div>
+      </section>
+      <section>
+        <h3>
+          Clock drift
+        </h3>
+        <p>
+          This specification also defines an API that provides sub-millisecond
+          time resolution of the zero time of the time origin, which requires
+          and exposes a <a>shared monotonic clock</a> to the application, and
+          that must be shared across all the browser contexts. The <a>shared
+          monotonic clock</a> does not need to be tied to physical time, but is
+          recommended to be set with respect to the [[ECMA-262]] definition of
+          <a>time</a> to avoid exposing new fingerprint entropy about the user
+          — e.g. this time can already be easily obtained by the application,
+          whereas exposing a new logical clock provides new information.
+        </p>
+        <p>
+          However, even with the above mechanism in place, the <a>shared
+          monotonic clock</a> may provide additional <a href=
+          "https://en.wikipedia.org/wiki/Clock_drift">clock drift</a>
+          resolution. Today, the application can timestamp the time-of-day and
+          monotonic time values (via <a>Date.now()</a> and
+          {{Performance/now()}}) at multiple points within the same context and
+          observe drift between them—e.g. due to automatic or user clock
+          adjustments. With the {{Performance/timeOrigin}} attribute, the
+          attacker can also compare the time at which <a>time origin</a> is
+          zero, as reported by the <a>shared monotonic clock</a>, against the
+          current time-of-day estimate of when it is zero (i.e. the difference
+          between `Date.now() - performance.now()` and
+          `performance.timeOrigin`) and potentially observe clock drift between
+          these clocks over a longer time period.
+        </p>
+        <p>
+          In practice, the same time drift can be observed by an application
+          across multiple navigations: the application can record the logical
+          time in each context and use a client or server time synchronization
+          mechanism to infer changes in the user's clock. Similarly,
+          lower-layer mechanisms such as TCP timestamps may reveal the same
+          high-resolution information to the server without the need for
+          multiple visits. As such, the information provided by this API should
+          not expose any significant or previously unavailable entropy about
+          the user.
+        </p>
+      </section>
     </section>
-  </section>
-  <section id="conformance">
-    <p>Some conformance requirements are phrased as requirements on attributes,
-    methods or objects. Such requirements are to be interpreted as requirements
-    on user agents.</p>
-  </section>
-  <section id="idl-index"></section>
-  <section class="appendix">
-    <h2>Acknowledgments</h2>
-    <p>Thanks to Arvind Jain, Angelos D. Keromytis, Boris Zbarsky, Jason Weber,
-    Karen Anderson, Nat Duca, Philippe Le Hegaret, Ryosuke Niwa, Simha
-    Sethumadhavan, Todd Reifsteck, Tony Gentilcore, Vasileios P. Kemerlis, Yoav
-    Weiss, and Yossef Oren for their contributions to this work.</p>
-  </section>
-</body>
+    <section id="conformance">
+      <p>
+        Some conformance requirements are phrased as requirements on
+        attributes, methods or objects. Such requirements are to be interpreted
+        as requirements on user agents.
+      </p>
+    </section>
+    <section id="idl-index"></section>
+    <section class="appendix">
+      <h2>
+        Acknowledgments
+      </h2>
+      <p>
+        Thanks to Arvind Jain, Angelos D. Keromytis, Boris Zbarsky, Jason
+        Weber, Karen Anderson, Nat Duca, Philippe Le Hegaret, Ryosuke Niwa,
+        Simha Sethumadhavan, Todd Reifsteck, Tony Gentilcore, Vasileios P.
+        Kemerlis, Yoav Weiss, and Yossef Oren for their contributions to this
+        work.
+      </p>
+    </section>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <title>High Resolution Time</title>
-  <script src='https://www.w3.org/Tools/respec/respec-w3c' async class=
-  'remove'></script>
-  <script class='remove'>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" async class=
+  "remove"></script>
+  <script class="remove">
   var respecConfig = {
     shortName: "hr-time-3",
     specStatus: "ED",
@@ -57,10 +57,8 @@
     current time in sub-millisecond resolution, such that it is not subject to
     system clock skew or adjustments.</p>
   </section>
-  <section id="sotd" data-link-for="Performance">
-
-  </section>
-  <section id="introduction" class='informative'>
+  <section id="sotd"></section>
+  <section id="introduction" class="informative">
     <h2>Introduction</h2>
     <p>The ECMAScript Language specification [[ECMA-262]] defines the
     <code><dfn data-no-export="" data-cite=
@@ -76,77 +74,76 @@
     remain the same.</p>
     <p>For example, the following script may record a positive number, negative
     number, or zero for computed <code>duration</code>:</p>
-    <pre class='example js'>
+    <pre class="example js">
       var mark_start = Date.now();
       doTask(); // Some task
       var duration = Date.now() - mark_start;
     </pre>
-    <p>For certain tasks this definition of time may not be sufficient as it:</p>
+    <p>For certain tasks this definition of time may not be sufficient as
+    it:</p>
     <ul>
-      <li>Does not have a stable monotonic clock, and as a result, it is subject to system clock skew.</li>
+      <li>Does not have a stable monotonic clock, and as a result, it is
+      subject to system clock skew.</li>
       <li>Does not provide sub-millisecond time resolution.</li>
     </ul>
-    <p data-link-for="Performance">This specification does not propose changing the behavior of
+    <p>This specification does not propose changing the behavior of
     <code><dfn data-no-export="" data-cite=
-    'ecma-262#sec-date.now'>Date.now()</dfn></code> [[ECMA-262]] as it is
+    "ecma-262#sec-date.now">Date.now()</dfn></code> [[ECMA-262]] as it is
     genuinely useful in determining the current value of the calendar time and
     has a long history of usage. The {{DOMHighResTimeStamp}} type,
-    <code>performance.</code>{{now}} method, and <code>performance.</code>{{timeOrigin}} attributes of
-    the {{Performance}} interface resolve the above issues by providing
+    {{Performance}}.{{Performance/now()}} method, and
+    {{Performance}}.{{Performance/timeOrigin}} attributes of the
+    {{Performance}} interface resolve the above issues by providing
     monotonically increasing time values with sub-millisecond resolution.</p>
-    <p class=note>Providing sub-millisecond resolution is not a mandatory part
-    of this specification.  Implementations may choose to limit the timer
+    <p class="note">Providing sub-millisecond resolution is not a mandatory
+    part of this specification. Implementations may choose to limit the timer
     resolution they expose for privacy and security reasons, and not expose
     sub-millisecond timers. Use-cases that rely on sub-millisecond resolution
     may not be satisfied when that happens.</p>
-    <section id='use-cases' class='informative'>
+    <section id="use-cases" class="informative">
       <h3>Use-cases</h3>
       <p>This specification defines a few different capabilities: it provides
-        timestamps based on a stable, monotonic clock, comparable across
-        contexts, with potential sub-millisecond resolution.</p>
-
+      timestamps based on a stable, monotonic clock, comparable across
+      contexts, with potential sub-millisecond resolution.</p>
       <p>The need for a stable monotonic clock when talking about performance
-        measurements stems from the fact that unrelated clock skew can distort
-        measurements and render them useless. For example, when attempting to
-        accurately measure the elapsed time of navigating to a Document,
-        fetching of resources or execution of script, a monotonically
-        increasing clock with sub-millisecond resolution is desired.</li>
-
+      measurements stems from the fact that unrelated clock skew can distort
+      measurements and render them useless. For example, when attempting to
+      accurately measure the elapsed time of navigating to a Document, fetching
+      of resources or execution of script, a monotonically increasing clock
+      with sub-millisecond resolution is desired.</p>
       <p>Comparing timestamps between contexts is essential e.g. when
-        synchronizing work between a {{Worker}} and the main thread or when
-        instrumenting such work in order to create a unified view of the event
-        timeline.</p>
-
+      synchronizing work between a {{Worker}} and the main thread or when
+      instrumenting such work in order to create a unified view of the event
+      timeline.</p>
       <p>Finally, the need for sub-millisecond timers revolves around the
-        following use-cases:</p>
-      <p><ul>
+      following use-cases:</p>
+      <ul>
         <li>Ability to schedule work in sub-millisecond intervals. That is
-          particularly important on the main thread, where work can interfere
-          with frame rendering which needs to happen in short and regular
-          intervals, to avoid user-visible jank.</li>
+        particularly important on the main thread, where work can interfere
+        with frame rendering which needs to happen in short and regular
+        intervals, to avoid user-visible jank.</li>
         <li>When calculating the frame rate of a script-based animation,
-          developers will need sub-millisecond resolution in order to determine if
-          an animation is drawing at 60 FPS. Without sub-millisecond resolution, a
-          developer can only determine if an animation is drawing at 58.8 FPS
-          (1000ms / 16) or 62.5 FPS (1000ms / 17).</li>
+        developers will need sub-millisecond resolution in order to determine
+        if an animation is drawing at 60 FPS. Without sub-millisecond
+        resolution, a developer can only determine if an animation is drawing
+        at 58.8 FPS (1000ms / 16) or 62.5 FPS (1000ms / 17).</li>
         <li>When collecting in-the-wild measurements of JS code (e.g. using
-          User-Timing), developers may be interested in gathering
-          sub-milliseconds timing of their functions, to catch regressions
-          early.</li>
+        User-Timing), developers may be interested in gathering
+        sub-milliseconds timing of their functions, to catch regressions
+        early.</li>
         <li>When attempting to cue audio to a specific point in an animation or
-          ensure that the audio and animation are perfectly synchronized,
-          developers will need to accurately measure the amount of time
-          elapsed.</li>
-      </ul></p>
+        ensure that the audio and animation are perfectly synchronized,
+        developers will need to accurately measure the amount of time
+        elapsed.</li>
+      </ul>
     </section>
-    <section id='examples' class='informative'>
+    <section id="examples" class="informative">
       <h3>Examples</h3>
-      <p data-link-for="Performance">A developer may wish to construct a timeline of their entire
+      <p>A developer may wish to construct a timeline of their entire
       application, including events from {{Worker}} or {{SharedWorker}}, which
       have different <a>time origin</a>s. To display such events on the same
-      timeline, the application can translate the {{DOMHighResTimeStamp}}s
-      with the help of the <code>performance.</code>{{timeOrigin}} attribute.</p>
-
+      timeline, the application can translate the {{DOMHighResTimeStamp}}s with
+      the help of the {{Performance}}.{{Performance/timeOrigin}} attribute.</p>
       <pre class="example js">
         // ---- worker.js -----------------------------
         // Shared worker script
@@ -226,8 +223,8 @@
       <li>Otherwise, the <a>time origin</a> is undefined.
       </li>
     </ul>
-    <p>To <dfn>get time origin timestamp</dfn>, given a
-    [=Realm/global object=] |global|, runs the following steps:</p>
+    <p>To <dfn>get time origin timestamp</dfn>, given a [=Realm/global object=]
+    |global|, runs the following steps:</p>
     <ol>
       <li>Assert: <var>global</var>'s <a>time origin</a> is not undefined.
       </li>
@@ -240,60 +237,59 @@
       </li>
       <li>Let |total| be the sum of <var>t1</var> and <var>t2</var>.</li>
       <li>Return the result of calling [=coarsen time=] with |total| and
-      |global|'s [=relevant settings object=]'s
-      [=environment settings object/cross-origin isolated capability=].</li>
+      |global|'s [=relevant settings object=]'s [=environment settings
+      object/cross-origin isolated capability=].</li>
     </ol>
-    <p class="note">The value returned by [=get time origin timestamp=] is the high
-    resolution time value at which <a>time origin</a> is zero. It may differ from the
-    value returned by <a>Date.now()</a> executed at "zero time", because the former is
-    recorded with respect to a <a>shared monotonic clock</a> that is not subject to
-    system and user clock adjustments, clock skew, and so on &mdash; see <a href=
-    "#sec-monotonic-clock"></a>.</p>
-    <p>
+    <p class="note">The value returned by [=get time origin timestamp=] is the
+    high resolution time value at which <a>time origin</a> is zero. It may
+    differ from the value returned by <a>Date.now()</a> executed at "zero
+    time", because the former is recorded with respect to a <a>shared monotonic
+    clock</a> that is not subject to system and user clock adjustments, clock
+    skew, and so on — see <a href="#sec-monotonic-clock"></a>.</p>
     <div data-algorithm="coarsen time">
-      The <dfn data-export="">coarsen time</dfn> algorithm, given a {{DOMHighResTimeStamp}}
-      |timestamp| and an optional boolean |crossOriginIsolatedCapability| (default false), runs the
-      following steps:
-
-       <ol>
-         <li>Let |time resolution| be 100 microseconds, or a higher
-           <a>implementation-defined</a> value.</li>
-         <li>If |crossOriginIsolatedCapability| is
-           true, set |time resolution| to be 5 microseconds, or a higher
-           <a>implementation-defined</a> value.</li>
-         <li>In an <a>implementation-defined</a> manner, coarsen and potentially
-           jitter |timestamp| such that its resolution will not exceed |time
-           resolution|.</li>
-         <li>Return |timestamp|.</li>
-       </ol>
+      The <dfn data-export="">coarsen time</dfn> algorithm, given a
+      {{DOMHighResTimeStamp}} |timestamp| and an optional boolean
+      |crossOriginIsolatedCapability| (default false), runs the following
+      steps:
+      <ol>
+        <li>Let |time resolution| be 100 microseconds, or a higher
+        <a>implementation-defined</a> value.
+        </li>
+        <li>If |crossOriginIsolatedCapability| is true, set |time resolution|
+        to be 5 microseconds, or a higher <a>implementation-defined</a> value.
+        </li>
+        <li>In an <a>implementation-defined</a> manner, coarsen and potentially
+        jitter |timestamp| such that its resolution will not exceed |time
+        resolution|.
+        </li>
+        <li>Return |timestamp|.</li>
+      </ol>
     </div>
     <div data-algorithm="relative high resolution time">
       The <dfn data-export="">relative high resolution time</dfn> given a
-      {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|,
-      is the result of the following steps:
+      {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|, is
+      the result of the following steps:
       <ol>
-        <li>Let |coarse time| be the result of calling [=coarsen time=] with |time| and
-        |global|'s [=relevant settings object=]'s
-        [=environment settings object/cross-origin isolated capability=].</li>
-        <li>Return the [=relative high resolution coarse time=] for |coarse time| and
-        |global|.</li>
-      </ol>
-
-      The <dfn data-export="">relative high resolution coarse time</dfn> given a
-      {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global object=] |global|,
-       is the difference between |coarseTime| and the result of
-        calling [=get time origin timestamp=] with |global|.
+        <li>Let |coarse time| be the result of calling [=coarsen time=] with
+        |time| and |global|'s [=relevant settings object=]'s [=environment
+        settings object/cross-origin isolated capability=].</li>
+        <li>Return the [=relative high resolution coarse time=] for |coarse
+        time| and |global|.</li>
+      </ol>The <dfn data-export="">relative high resolution coarse time</dfn>
+      given a {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global
+      object=] |global|, is the difference between |coarseTime| and the result
+      of calling [=get time origin timestamp=] with |global|.
     </div>
-    </p>
     <p>The <dfn data-export="">current high resolution time</dfn> given a
     [=/global object=] |current global| must return the result of [=relative
     high resolution time=] given [=unsafe shared current time=] and |current
     global|.</p>
-    <p>The <dfn data-export="">coarsened shared current time</dfn> given an optional boolean
-    |crossOriginIsolatedCapability| (default false), must return the result of calling
-    [=coarsen time=] with the [=unsafe shared current time=] and |crossOriginIsolatedCapability|.
+    <p>The <dfn data-export="">coarsened shared current time</dfn> given an
+    optional boolean |crossOriginIsolatedCapability| (default false), must
+    return the result of calling [=coarsen time=] with the [=unsafe shared
+    current time=] and |crossOriginIsolatedCapability|.</p>
     <p>The <dfn data-export="">unsafe shared current time</dfn> must return the
-    current value of the <a>shared monotonic clock</a>.
+    current value of the <a>shared monotonic clock</a>.</p>
   </section>
   <section id="sec-domhighrestimestamp">
     <h3>The <dfn data-export="">DOMHighResTimeStamp</dfn> typedef</h3>
@@ -301,7 +297,7 @@
     milliseconds, measured relative from the <a>time origin</a>, <a>shared
     monotonic clock</a>, or a time value that represents a duration between two
     {{DOMHighResTimeStamp}}s.</p>
-    <pre class='idl'>
+    <pre class="idl">
       typedef double DOMHighResTimeStamp;
     </pre>
     <p>A {{DOMHighResTimeStamp}} SHOULD represent a time in milliseconds
@@ -311,7 +307,7 @@
   <section id="sec-performance" data-dfn-for="Performance" data-link-for=
   "Performance">
     <h3>The <dfn>Performance</dfn> interface</h3>
-    <pre class='idl' data-cite='DOM'>
+    <pre class="idl">
       [Exposed=(Window,Worker)]
       interface Performance : EventTarget {
           DOMHighResTimeStamp now();
@@ -321,20 +317,20 @@
     </pre>
     <section>
       <h3>`now()` method</h3>
-      <p data-tests='basic.any.html, basic.any.worker.html'>The
+      <p data-tests="basic.any.html, basic.any.worker.html">The
       <dfn>now()</dfn> method MUST return the <a>current high resolution
       time</a>.</p>
     </section>
     <section>
       <h3>`timeOrigin` attribute</h3>
-      <p data-tests='timeOrigin.html, window-worker-timeOrigin.window.html'>The
+      <p data-tests="timeOrigin.html, window-worker-timeOrigin.window.html">The
       <dfn>timeOrigin</dfn> attribute MUST return the value returned by [=get
       time origin timestamp=] for the <a>relevant global object</a> of
       [=this=].</p>
     </section>
     <section>
       <h3>`toJSON()` method</h3>
-      <p data-tests='performance-tojson.html'>When <dfn>toJSON()</dfn> is
+      <p data-tests="performance-tojson.html">When <dfn>toJSON()</dfn> is
       called, run [[WEBIDL]]'s <a>default toJSON steps</a>.</p>
     </section>
   </section>
@@ -346,44 +342,45 @@
       <p>The <dfn>performance</dfn> attribute on the interface mixin
       {{WindowOrWorkerGlobalScope}} allows access to performance related
       attributes and methods from the [=Realm/global object=].</p>
-      <pre class='idl' data-cite='HTML'>
+      <pre class="idl">
       partial interface mixin WindowOrWorkerGlobalScope {
         [Replaceable] readonly attribute Performance performance;
       };
   </pre>
     </section>
   </section>
-  <section id="sec-monotonic-clock" data-link-for="Performance">
+  <section id="sec-monotonic-clock">
     <h3>Monotonic Clock</h3>
-    <p data-tests='monotonic-clock.any.html, monotonic-clock.any.worker.html'>
+    <p data-tests="monotonic-clock.any.html, monotonic-clock.any.worker.html">
     The time values returned when calling the {{Performance/now()}} method on
     {{Performance}} objects with the same <a>time origin</a> MUST use the same
     <dfn data-export="">monotonic clock</dfn> that is monotonically increasing
     and not subject to system clock adjustments or system clock skew. The
     difference between any two chronologically recorded time values returned
-    from the {{Performance.now()}} method MUST never be negative if the two
+    from the {{Performance/now()}} method MUST never be negative if the two
     time values have the same <a>time origin</a>.</p>
-    <p data-link-for="Performance" data-tests='test_cross_frame_start.html'>The time values returned when
-    getting <code>performance.</code>{{timeOrigin}} MUST use the same <dfn>shared monotonic clock</dfn> that is shared by <a>time origin</a>s, is
+    <p data-tests="test_cross_frame_start.html">The time values returned when
+    getting {{Performance}}.{{Performance/timeOrigin}} MUST use the same
+    <dfn>shared monotonic clock</dfn> that is shared by <a>time origin</a>s, is
     monotonically increasing and not subject to system clock adjustments or
     system clock skew, and whose reference point is the [[ECMA-262]]
     <dfn data-no-export="" data-cite=
     "ECMA-262#sec-time-values-and-time-range">time</dfn> definition - see
     [[[#sec-privacy-security]]].</p>
-    <p class="note">The user agent can reset its <a>shared monotonic clock</a> across
-    browser restarts, or whenever starting an isolated browsing session—e.g.
-    incognito or similar browsing mode. As a result, developers should not use
-    shared timestamps as absolute time that holds its monotonic properties
-    across all past, present, and future contexts; in practice, the monotonic
-    properties only apply for contexts that can reach each other by exchanging
-    messages via one of the provided messaging mechanisms - e.g. `postMessage`,
-    `BroadcastChannel`, etc.</p>
+    <p class="note">The user agent can reset its <a>shared monotonic clock</a>
+    across browser restarts, or whenever starting an isolated browsing
+    session—e.g. incognito or similar browsing mode. As a result, developers
+    should not use shared timestamps as absolute time that holds its monotonic
+    properties across all past, present, and future contexts; in practice, the
+    monotonic properties only apply for contexts that can reach each other by
+    exchanging messages via one of the provided messaging mechanisms - e.g.
+    `postMessage`, `BroadcastChannel`, etc.</p>
     <p class="note">In certain scenarios (e.g. when a tab is backgrounded), the
     user agent may choose to throttle timers and periodic callbacks run in that
     context or even freeze them entirely. Any such throttling should not affect
     the resolution or accuracy of the time returned by the monotonic clock.</p>
   </section>
-  <section id="sec-privacy-security" data-link-for="Performance">
+  <section id="sec-privacy-security">
     <h3>Privacy and Security</h3>
     <section>
       <h3>Clock resolution</h3>
@@ -397,28 +394,26 @@
       <p>However, access to the same accurate timing information can sometimes
       be also used for malicious purposes by an attacker to guess and infer
       data that they can't see or access otherwise. For example, cache attacks,
-      statistical fingerprinting and microarchitectural attacks are a privacy
+      statistical fingerprinting and micro-architectural attacks are a privacy
       and security concern where a malicious web site may use high resolution
       timing data of various browser or application-initiated operations to
       differentiate between subset of users, identify a particular user or
       reveal unrelated but same-process user data - see [[?CACHE-ATTACKS]] and
       [[SPECTRE]] for more background.</p>
-      <p data-tests='timing-attack.html'>This specification defines an API that
+      <p data-tests="timing-attack.html">This specification defines an API that
       provides sub-millisecond time resolution, which is more accurate than the
       previously available millisecond resolution exposed by {{DOMTimeStamp}}.
       However, even without this new API an attacker may be able to obtain
       high-resolution estimates through repeat execution and statistical
       analysis.</p>
-      <p>To ensure that the new API does not significantly improve the
-      accuracy or speed of such attacks, the minimum resolution of the
+      <p>To ensure that the new API does not significantly improve the accuracy
+      or speed of such attacks, the minimum resolution of the
       {{DOMHighResTimeStamp}} type should be inaccurate enough to prevent
       attacks.</p>
-
       <p>Where necessary, the user agent should set higher resolution values to
       |time resolution| in [=coarsen time=]'s processing model, to address
-      privacy and security concerns due to architecture or software constraints,
-      or other considerations.</p>
-
+      privacy and security concerns due to architecture or software
+      constraints, or other considerations.</p>
       <p>In order to mitigate such attacks user agents may deploy any technique
       they deem necessary. Deployment of those techniques may vary based on the
       browser's architecture, the user's device, the content and its ability to
@@ -460,13 +455,13 @@
       monotonic clock</a> may provide additional <a href=
       "https://en.wikipedia.org/wiki/Clock_drift">clock drift</a> resolution.
       Today, the application can timestamp the time-of-day and monotonic time
-      values (via <a>Date.now()</a> and {{Performance.now()}}) at multiple
+      values (via <a>Date.now()</a> and {{Performance/now()}}) at multiple
       points within the same context and observe drift between them—e.g. due to
-      automatic or user clock adjustments. With the {{Performance.timeOrigin}}
+      automatic or user clock adjustments. With the {{Performance/timeOrigin}}
       attribute, the attacker can also compare the time at which <a>time
       origin</a> is zero, as reported by the <a>shared monotonic clock</a>,
       against the current time-of-day estimate of when it is zero (i.e. the
-      difference between `Date.now()-performance.now()` and
+      difference between `Date.now() - performance.now()` and
       `performance.timeOrigin`) and potentially observe clock drift between
       these clocks over a longer time period.</p>
       <p>In practice, the same time drift can be observed by an application

--- a/index.html
+++ b/index.html
@@ -373,8 +373,7 @@
         see <a href="#clock-resolution"></a> for additional considerations.
       </p>
     </section>
-    <section id="sec-performance" data-dfn-for="Performance" data-link-for=
-    "Performance">
+    <section id="sec-performance" data-dfn-for="Performance">
       <h3>
         The <dfn>Performance</dfn> interface
       </h3>
@@ -419,8 +418,7 @@
       <h2>
         Extensions to `WindowOrWorkerGlobalScope` mixin
       </h2>
-      <section data-dfn-for="WindowOrWorkerGlobalScope" data-link-for=
-      "WindowOrWorkerGlobalScope">
+      <section data-dfn-for="WindowOrWorkerGlobalScope">
         <h3>
           The <code>performance</code> attribute
         </h3>

--- a/tidyconfig.txt
+++ b/tidyconfig.txt
@@ -1,4 +1,4 @@
 char-encoding: utf8
-indent: auto
+indent: yes
 wrap: 80
 tidy-mark: no


### PR DESCRIPTION
This workflow will automatically tidy up documents _after_ a pull request is merged, and it sends a pull request if was fixed by tidy. 

This allows folks to make contributions without needing to worry *too much* about the markup they are writing.

@yoavweiss, 99% tidy will do the right thing. However, if a contribution has garbage HTML (e..g, `<section>` is not closed), tidy will try to recover. In such cases, please double check that tidy has done what we want. 

Any issues, just ping!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/118.html" title="Last updated on Jun 7, 2021, 5:51 AM UTC (c8d0473)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/118/94f3eb5...c8d0473.html" title="Last updated on Jun 7, 2021, 5:51 AM UTC (c8d0473)">Diff</a>