### PR TITLE
Define the LegacyTimeStamp typedef

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,6 +372,25 @@
         see <a href="#clock-resolution"></a> for additional considerations.
       </p>
     </section>
+    <section>
+      <h3>
+        The <dfn>LegacyTimeStamp</dfn> typedef
+      </h3>
+      <pre class="idl">
+        typedef unsigned long long LegacyTimeStamp;
+      </pre>
+      <aside class="note" title="Legacy platform feature">
+        <p>
+          The use of `LegacyTimeStamp`, known previously as `DOMTimeStamp`, is
+          discouraged. Wherever possible use {{DOMHighResTimeStamp}} instead.
+        </p>
+      </aside>
+      <p>
+        A {{LegacyTimeStamp}} represents the milliseconds since 00:00:00 UTC on
+        1 January 1970. Specifications that use this type define how the number
+        of milliseconds are interpreted.
+      </p>
+    </section>
     <section id="sec-performance" data-dfn-for="Performance">
       <h3>
         The <dfn>Performance</dfn> interface


### PR DESCRIPTION
Closes #123 

See https://github.com/heycam/webidl/issues/2 for discussion. Bugs have been filed with the relevant specifications telling them to move away from using DOMTimeStamp. 

> In particular, if the change results in potential backwards compatibility issues and content breakage, it needs to be justified.

As this is a typedef, it has no impact on web compat itself.  

For normative spec changes, please get implementation commitments anf file issues on the various engines during the review process. All tasks should be complete before merging. 

Implementation commitment - primarily for "change" and other normative changes:

- [ ] [WebKit](https://bugs.webkit.org/???)
- [ ] [Chromium](https://bugs.chromium.org/???)
- [ ] [Gecko](http://bugzilla.mozilla.org/???)

Tasks:

- [ ] [Added tests] - WPT will handle this automatically once each dependent spec is updated. 
