### PR TITLE
Editorial: cleanup stray DOMTimeStamp usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,7 @@
         representing time in milliseconds since 01 January, 1970 UTC. For most
         purposes, this definition of time is sufficient as these values
         represent time to millisecond precision for any instant that is within
-        approximately 285,616 years from 01 January, 1970 UTC. The
-        {{DOMTimeStamp}} is defined similarly [[WEBIDL]].
+        approximately 285,616 years from 01 January, 1970 UTC.
       </p>
       <p>
         In practice, these definitions of time are subject to both clock skew
@@ -546,7 +545,7 @@
         <p data-tests="timing-attack.html">
           This specification defines an API that provides sub-millisecond time
           resolution, which is more accurate than the previously available
-          millisecond resolution exposed by {{DOMTimeStamp}}. However, even
+          millisecond resolution exposed by {{EpochTimeStamp}}. However, even
           without this new API an attacker may be able to obtain
           high-resolution estimates through repeat execution and statistical
           analysis.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/126.html" title="Last updated on Oct 10, 2021, 11:59 PM UTC (e390461)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/126/160cde6...e390461.html" title="Last updated on Oct 10, 2021, 11:59 PM UTC (e390461)">Diff</a>