### PR TITLE
Remove own version of `timeOrigin` definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,15 +236,24 @@
         Time Origin
       </h3>
       <p>
-        The <dfn data-export="">time origin</dfn> is the [=Realm/global object=]'s
-        [=relevant settings object=]'s [=environment settings object/time origin=].
+        The <dfn data-export="">time origin</dfn> is the time value from which
+        time is measured:
       </p>
       <p>
         To <dfn>get time origin timestamp</dfn>, given a [=Realm/global
         object=] |global|, runs the following steps:
       </p>
       <ol>
-        <li>Assert: <var>global</var>'s <a>time origin</a> is not undefined.
+        <li>
+          <p>Let <var>timeOrigin</var> be |global|'s [=relevant settings object=]'s
+          [=environment settings object/time origin=].
+
+          <p class="note">
+            In {{Window}} contexts, this value represents the time when
+            [=navigate|navigation has started=]. In {{Worker}} and {{ServiceWorker}} contents, this
+            value represent the time when the [=run a worker|worker is run=].
+            [[service-workers]]
+          </p>
         </li>
         <li>Let <var>t1</var> be the {{DOMHighResTimeStamp}} representing the
         high resolution time at which the <a>shared monotonic clock</a> is
@@ -252,7 +261,7 @@
         </li>
         <li>Let <var>t2</var> be the {{DOMHighResTimeStamp}} representing the
         high resolution time value of the <a>shared monotonic clock</a> at
-        <var>global</var>'s <a>time origin</a>.
+        <var>timeOrigin</var>.
         </li>
         <li>Let |total| be the sum of <var>t1</var> and <var>t2</var>.
         </li>

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
         time is measured:
       </p>
       <p>
-        To <dfn>get time origin timestamp</dfn>, given a [=Realm/global
+        To <dfn>get time origin timestamp</dfn>, given a [=/global
         object=] |global|, runs the following steps:
       </p>
       <ol>

--- a/index.html
+++ b/index.html
@@ -236,36 +236,9 @@
         Time Origin
       </h3>
       <p>
-        The <dfn data-export="">time origin</dfn> is the time value from which
-        time is measured:
+        The <dfn data-export="">time origin</dfn> is the [=Realm/global object=]'s
+        [=relevant settings object=]'s [=environment settings object/time origin=].
       </p>
-      <ul>
-        <li>If the [=Realm/global object=] is a {{Window}} object, the <a>time
-        origin</a> MUST be equal to:
-          <ul>
-            <li>the time when the <a data-cite=
-            "HTML/browsers.html#creating-a-new-browsing-context">browsing
-            context is first created</a> if there is no previous document;
-            </li>
-            <li>otherwise, the time of the user confirming the navigation
-            during the previous document's <a data-cite=
-            "HTML/browsing-the-web.html#prompt-to-unload-a-document">prompt to
-            unload algorithm</a>, if a previous document exists and if the
-            confirmation dialog was displayed;
-            </li>
-            <li>otherwise, the time of starting the <a data-lt=
-            "navigate">navigation</a> responsible for loading the <a data-lt=
-            "associated document">Window object's newest Document object</a>.
-            </li>
-          </ul>
-        </li>
-        <li>If the [=Realm/global object=] is a {{WorkerGlobalScope}} object,
-        the <a>time origin</a> MUST be equal to the <a>official moment of
-        creation</a> of the worker.
-        </li>
-        <li>Otherwise, the <a>time origin</a> is undefined.
-        </li>
-      </ul>
       <p>
         To <dfn>get time origin timestamp</dfn>, given a [=Realm/global
         object=] |global|, runs the following steps:


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/7339

`time origin` is now an `environment settings object` algorithm,
so the reference here should forward there.

Closes #131

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

- chore: fixes unrelated to the spec itself (e.g., fix to Github action, html tidy, spec config, etc.). 
- editorial: a non-normative change to the spec (e.g., fixing an example or typo, adding a note).
- change: a normative change to existing engine behavior.
- And use none if it's a new normative requirement. 

If this is a "change", please explain what's significantly changing. 
In particular, if the change results in potential backwards compatibility issues and content breakage, it needs to be justified.

For normative spec changes, please get implementation commitments anf file issues on the various engines during the review process. All tasks should be complete before merging. 

Implementation commitment - primarily for "change" and other normative changes:

- [ ] [WebKit](https://bugs.webkit.org/???)
- [ ] [Chromium](https://bugs.chromium.org/???)
- [ ] [Gecko](http://bugzilla.mozilla.org/???)

Tasks:

- [ ] [Added tests](https://github.com/web-platform-tests/wpt/pulls/???)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/132.html" title="Last updated on Dec 1, 2021, 6:19 AM UTC (9f25f43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/132/f1d5dd4...9f25f43.html" title="Last updated on Dec 1, 2021, 6:19 AM UTC (9f25f43)">Diff</a>