### PR TITLE
Revert "Expose everywhere"

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
         The <dfn>Performance</dfn> interface
       </h3>
       <pre class="idl">
-      [Exposed=*]
+      [Exposed=(Window,Worker)]
       interface Performance : EventTarget {
           DOMHighResTimeStamp now();
           readonly attribute DOMHighResTimeStamp timeOrigin;


### PR DESCRIPTION
Reverts w3c/hr-time#130 given discussion on https://w3c.github.io/web-performance/meetings/2022/2022-06-23/index.html#h.1of8nktf4mlh


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/138.html" title="Last updated on Jul 22, 2022, 2:01 PM UTC (639ddf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/138/e7285a2...639ddf6.html" title="Last updated on Jul 22, 2022, 2:01 PM UTC (639ddf6)">Diff</a>