### PR TITLE
editorial: Introduce clocks, moments, and durations

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,14 @@
     xref: "web-platform",
     mdn: "hr-time",
     highlightVars: true,
+    localBiblio: {
+      "Temporal": {
+        href: "https://tc39.es/proposal-temporal/",
+        title: "Temporal",
+        status: "Stage 3 Proposal",
+        publisher: "ECMA TC39",
+      },
+    },
     };
     </script>
   </head>
@@ -241,7 +249,7 @@
         </h4>
         <p>
           A <dfn>clock</dfn> tracks the passage of time and can report the
-          <dfn>current time</dfn> that an algorithm step is executing. There are
+          <dfn>unsafe current time</dfn> that an algorithm step is executing. There are
           many kinds of clocks. All clocks on the web platform attempt to count
           1 millisecond of clock time per 1 millisecond of real-world time, but
           they differ in how they handle cases where they can't be exactly
@@ -249,11 +257,11 @@
         </p>
         <ul>
           <li>The <dfn data-export>wall clock</dfn>'s <dfn data-dfn-for="wall clock"
-          data-export>current time</dfn>
+          data-export>unsafe current time</dfn>
           is always as close as possible to a human user's notion of time. Since
           a computer sometimes runs slow or fast or loses track of time, its
           [=wall clock=] sometimes needs to be adjusted, which means the [=wall
-          clock/current time=] can decrease, making it unreliable for
+          clock/unsafe current time=] can decrease, making it unreliable for
           performance measurement or recording the orders of events. The web
           platform shares a [=wall clock=] with [[ECMA-262]] <dfn
           data-no-export="" data-cite=
@@ -263,7 +271,7 @@
           <li>
             <p>
               The <dfn data-export>monotonic clock</dfn>'s <dfn data-export
-              data-dfn-for="monotonic clock">current time</dfn> never decreases,
+              data-dfn-for="monotonic clock">unsafe current time</dfn> never decreases,
               so it can't be changed by system clock adjustments. It only exists
               within a single execution of the [=user agent=], so it can't be
               used to compare events that might happen in different executions.
@@ -295,7 +303,7 @@
           Moments and Durations
         </h4>
         <p>
-          Each [=clock=]'s [=current time=] returns an <dfn>unsafe
+          Each [=clock=]'s [=unsafe current time=] returns an <dfn>unsafe
           moment</dfn>. [=Coarsen time=] converts these [=unsafe moments=] to
           <dfn data-export data-lt="moment">coarsened moments</dfn> or just
           [=moments=]. [=Unsafe moments=] and [=moments=] from different
@@ -311,6 +319,146 @@
           be added to a [=moment=] from a second [=clock=], to produce another
           [=moment=] on that second [=clock=].
         </p>
+        <p>
+          [=Durations=] can be used implicitly as {{DOMHighResTimeStamp}}s. To
+          <dfn>implicitly convert a duration to a timestamp</dfn>, given a
+          [=duration=] |d|, return the number of milliseconds in |d|.
+        </p>
+      </section>
+    </section>
+    <section id="sec-tools">
+      <h3>
+        Tools for Specification Authors
+      </h3>
+      <p>
+        For measuring time within a single page (within the context of a single
+        [=environment settings object=]), use the |settingsObject|'s <dfn
+        data-export data-dfn-for="environment settings object">current relative
+        timestamp</dfn>, defined as the [=duration=] from |settingsObject|'s
+        [=environment settings object/time origin=] to the |settingsObject|'s
+        [=environment settings object/current monotonic time=]. This value can
+        be exposed directly to Javascript using the [=duration=]'s [=implicitly
+        convert a duration to a timestamp|implicit conversion=] to
+        {{DOMHighResTimeStamp}}.
+      </p>
+      <p>
+        For measuring time within a single UA execution when an [=environment
+        settings object=]'s [=environment settings object/time origin=] isn't
+        an appropriate base for comparison, create [=moments=] using a |settings
+        object|'s <dfn data-dfn-for="environment settings object">current
+        monotonic time</dfn>, defined as [=coarsen time=] applied to the
+        [=monotonic clock=]'s [=monotonic clock/unsafe current time=] and the
+        |settings object|'s [=environment settings object/cross-origin isolated
+        capability=].
+      </p>
+      <p>
+        [=Moments=] from the [=monotonic clock=] can't be directly represented
+        in Javascript or HTTP. Instead, expose a [=duration=] between two such
+        [=moments=].
+      </p>
+      <p>
+        For measuring time across multiple UA executions, create [=moments=]
+        using a |settingsObject|'s <dfn data-export
+        data-dfn-for="environment settings object">current wall time</dfn>,
+        defined as [=coarsen time=] applied to the [=wall clock=]'s [=wall
+        clock/unsafe current time=] and |settingsObject|'s [=environment
+        settings object/cross-origin isolated capability=].
+      </p>
+      <p class="advisement">
+        When using [=moments=] from the [=wall clock=], be sure that your design
+        does something reasonable when the user adjusts their clock either
+        forward or backward.
+      </p>
+      <p>
+        [=Moments=] from the [=wall clock=] can be represented in Javascript by
+        passing the number of milliseconds from the [=Unix epoch=] to that
+        [=moment=] into the {{Date}} constructor, or by passing the number of
+        nanoseconds from the [=Unix epoch=] to that [=moment=] into the
+        <a data-link-type="idl"
+        data-cite="Temporal#sec-temporal-instant-constructor">Temporal.Instant</a>
+        constructor.
+      </p>
+      <p class="advisement" data-tracking-vector>
+        Avoid sending similar representations between computers, as doing so
+        will expose the user's clock skew, which is a [=tracking vector=].
+        Instead, use an approach similar to [=monotonic clock=] [=moments=] of
+        sending a duration between two [=moments=].
+      </p>
+      <section id="sec-tools-examples">
+        <h3>
+          Examples
+        </h3>
+        <div class="example" id="example-current-relative-timestamp">
+          <p>
+            The time a DOM event happens can be reported using:
+          </p>
+          <ol start="7">
+            <li>
+              Initialize |event|'s {{Event/timeStamp}} attribute to [=this=]'s
+              [=relevant settings object=]'s [=environment settings
+              object/current relative timestamp=].
+            </li>
+          </ol>
+        </div>
+        <div class="example" id="example-current-monotonic-time">
+          <p>
+            The age of an error report can be computed using:
+          </p>
+          <ol start="7">
+            <li>
+              Initialize |report|'s <a
+              data-cite="reporting#report-timestamp">generation time</a> to
+              |settings|' [=environment settings object/current monotonic
+              time=].
+            </li>
+          </ol>
+          <p>
+            Later:
+          </p>
+          <ol start="2">
+            <li>
+              Let |data| be a map with the following key/value pairs:
+              <dl>
+                <dt>age</dt>
+                <dd>
+                  The number of milliseconds between |report|'s <a
+                  data-cite="reporting#report-timestamp">generation time</a> and
+                  |context|'s [=relevant settings object=]'s [=environment
+                  settings object/current monotonic time=], rounded to the nearest integer.
+                </dd>
+                <dd>...</dd>
+              </dl>
+            </li>
+          </ol>
+        </div>
+        <div class="example" id="example-current-wall-time">
+          <p>
+            Multi-day attribution report expirations can be handled as:
+          </p>
+          <ol start="2">
+            <li>
+              Let |source| be a new attribution
+              source struct whose items are:
+              <dl>
+                <dt>...</dt>
+                <dt>source time</dt>
+                <dd>|context|'s [=environment settings object/current wall time=]</dd>
+                <dt>expiry</dt>
+                <dd><a data-cite="html#parse-a-duration-string">parse a duration string</a> from <code>|value|["expiry"]</code></dd>
+              </dl>
+            </li>
+          </ol>
+          <p>
+            Days later:
+          </p>
+          <ol start="2">
+            <li>
+              If |context|'s [=environment settings object/current wall time=]
+              is less than |source|'s source time + |source|'s expiry, send a
+              report.
+            </li>
+          </ol>
+        </div>
       </section>
     </section>
     <section id="sec-time-origin">
@@ -329,20 +477,21 @@
       </p>
       <ol data-algorithm=
       "initialize the estimated monotonic time of the Unix epoch">
-        <li>Let |wall time| be the [=wall clock=]'s [=wall clock/current
+        <li>Let |wall time| be the [=wall clock=]'s [=wall clock/unsafe current
         time=].
         </li>
         <li>Let |monotonic time| be the [=monotonic clock=]'s [=monotonic
-        clock/current time=].
+        clock/unsafe current time=].
         </li>
         <li>Initialize the [=estimated monotonic time of the Unix epoch=] to
         <code>|monotonic time| - (|wall time| - [=Unix epoch=])</code>.
         </li>
       </ol>
       <div class="issue">
-        The above set of settings objects needs to be specified better. It's
-        similar to <a data-cite="html/browsers.html#familiar-with">familiar
-        with</a> but includes {{Worker}}s.
+        The above set of settings-objects-that-could-possibly-communicate needs
+        to be specified better. It's similar to <a
+        data-cite="html/browsers.html#familiar-with">familiar with</a> but
+        includes {{Worker}}s.
       </div>
       <p>
         Performance measurements report a [=duration=] from a [=moment=] early
@@ -434,7 +583,7 @@
       </p>
       <p>
         The <dfn data-export="">unsafe shared current time</dfn> must return
-        the [=monotonic clock/current time=] of the <a>monotonic clock</a>.
+        the [=monotonic clock/unsafe current time=] of the <a>monotonic clock</a>.
       </p>
       <p>
         To get an <dfn data-export="">epoch-relative timestamp</dfn>,
@@ -442,7 +591,7 @@
       </p>
       <ol class="algorithm">
         <li>If |time| was not passed, set |time| to the [=wall clock=]'s [=wall
-        clock/current time=].
+        clock/unsafe current time=].
         </li>
         <li>Assert: |time| is greater than or equal to 1 January 1970 00:00:00
         UTC.

--- a/index.html
+++ b/index.html
@@ -275,9 +275,13 @@
               so it can't be changed by system clock adjustments. The
               [=monotonic clock=] only exists within a single execution of the
               [=user agent=], so it can't be used to compare events that might
-              happen in different executions. Since it can't be adjusted to
-              match the user's notion of time, it's also not appropriate for
-              communicating with the user.
+              happen in different executions.
+            </p>
+            <p class="note">
+              Since the [=monotonic clock=] can't be adjusted to match the
+              user's notion of time, it should be used for measurement, rather
+              than user-visible times. For any time communication with the user,
+              use the wall clock.
             </p>
             <p class="note">
               The user agent can pick a new [=estimated monotonic time of the

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
         "ECMA-262#sec-date-objects">Date</dfn></code> object as a time value
         representing time in milliseconds since 01 January, 1970 UTC. For most
         purposes, this definition of time is sufficient as these values
-        represent time to millisecond precision for any instant that is within
+        represent time to millisecond precision for any moment that is within
         approximately 285,616 years from 01 January, 1970 UTC.
       </p>
       <p>
@@ -291,24 +291,24 @@
       </section>
       <section>
         <h4>
-          Instants and Durations
+          Moments and Durations
         </h4>
         <p>
           Each [=clock=]'s [=current time=] returns an <dfn>unsafe
-          instant</dfn>. [=Coarsen time=] converts these [=unsafe instants=] to
-          <dfn data-export data-lt="instant">coarsened instants</dfn> or just
-          [=instants=]. [=Unsafe instants=] and [=instants=] from different
+          moment</dfn>. [=Coarsen time=] converts these [=unsafe moments=] to
+          <dfn data-export data-lt="moment">coarsened moments</dfn> or just
+          [=moments=]. [=Unsafe moments=] and [=moments=] from different
           clocks are not comparable.
         </p>
         <p>
-          A <dfn data-export>duration</dfn> is the distance from one [=instant=]
-          to another [=instant=] from the same [=clock=]. One of the two
-          instants can also be an [=unsafe instant=]. [=Durations=] are measured
+          A <dfn data-export>duration</dfn> is the distance from one [=moment=]
+          to another [=moment=] from the same [=clock=]. One of the two
+          moments can also be an [=unsafe moment=]. [=Durations=] are measured
           in milliseconds, seconds, etc. Since all [=clocks=] attempt to count
           at the same rate, [=durations=] don't have an associated [=clock=],
-          and a [=duration=] calculated from two [=instants=] on one clock can
-          be added to an [=instant=] from a second [=clock=], to produce another
-          [=instant=] on that second [=clock=].
+          and a [=duration=] calculated from two [=moments=] on one clock can
+          be added to an [=moment=] from a second [=clock=], to produce another
+          [=moment=] on that second [=clock=].
         </p>
       </section>
     </section>
@@ -329,13 +329,13 @@
       </p>
       <p>
         Performance measurements report a [=duration=] on the [=monotonic
-        clock=] from an [=instant=] early in the initialization of a relevant
-        [=environment settings object=]. That [=instant=] is stored in that
+        clock=] from an [=moment=] early in the initialization of a relevant
+        [=environment settings object=]. That [=moment=] is stored in that
         settings object's [=environment settings object/time origin=].
       </p>
       <p>
         To <dfn>get time origin timestamp</dfn>, given a [=/global object=]
-        |global|, run the following steps, which return an [=instant=] on the
+        |global|, run the following steps, which return an [=moment=] on the
         [=wall clock=]:
       </p>
       <ol>
@@ -371,7 +371,7 @@
         adjustments, clock skew, and so on.
       </p>
       <div data-algorithm="coarsen time">
-        The <dfn data-export="">coarsen time</dfn> algorithm, given an [=unsafe instant=]
+        The <dfn data-export="">coarsen time</dfn> algorithm, given an [=unsafe moment=]
         |timestamp| on some [=clock=] and an optional boolean
         |crossOriginIsolatedCapability| (default false), runs the following
         steps:
@@ -387,7 +387,7 @@
           potentially jitter |timestamp| such that its resolution will not
           exceed |time resolution|.
           </li>
-          <li>Return |timestamp| as an [=instant=].
+          <li>Return |timestamp| as an [=moment=].
           </li>
         </ol>
       </div>

--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
         <ul>
           <li>The <dfn data-export>wall clock</dfn>'s <dfn data-dfn-for="wall clock"
           data-export>unsafe current time</dfn>
-          is always as close as possible to a human user's notion of time. Since
+          is always as close as possible to a user's notion of time. Since
           a computer sometimes runs slow or fast or loses track of time, its
           [=wall clock=] sometimes needs to be adjusted, which means the [=wall
           clock/unsafe current time=] can decrease, making it unreliable for
@@ -279,14 +279,17 @@
               it's also not appropriate for communicating with the user.
             </p>
             <p class="note">
-              The user agent can reset its <a>monotonic clock</a> across
-              browser restarts, or whenever starting an isolated browsing
-              session—e.g. incognito or similar browsing mode. As a result,
+              The user agent can pick a new [=estimated monotonic time of the
+              Unix epoch=] when the browser restarts, when it starts an isolated
+              browsing session—e.g. incognito or a similar browsing mode—or when
+              it creates an [=environment settings object=] that can't
+              communicate with any existing settings objects. As a result,
               developers should not use shared timestamps as absolute time that holds
               its monotonic properties across all past, present, and future contexts;
               in practice, the monotonic properties only apply for contexts that can
               reach each other by exchanging messages via one of the provided
-              messaging mechanisms - e.g. `postMessage`, `BroadcastChannel`, etc.
+              messaging mechanisms - e.g. {{Window/postMessage(message,
+              options)}}, {{BroadcastChannel}}, etc.
             </p>
             <p class="note">
               In certain scenarios (e.g. when a tab is backgrounded), the user agent
@@ -337,40 +340,61 @@
         timestamp</dfn>, defined as the [=duration=] from |settingsObject|'s
         [=environment settings object/time origin=] to the |settingsObject|'s
         [=environment settings object/current monotonic time=]. This value can
-        be exposed directly to Javascript using the [=duration=]'s [=implicitly
+        be exposed directly to JavaScript using the [=duration=]'s [=implicitly
         convert a duration to a timestamp|implicit conversion=] to
         {{DOMHighResTimeStamp}}.
       </p>
       <p>
         For measuring time within a single UA execution when an [=environment
         settings object=]'s [=environment settings object/time origin=] isn't
-        an appropriate base for comparison, create [=moments=] using a |settings
-        object|'s <dfn data-dfn-for="environment settings object">current
-        monotonic time</dfn>, defined as [=coarsen time=] applied to the
-        [=monotonic clock=]'s [=monotonic clock/unsafe current time=] and the
-        |settings object|'s [=environment settings object/cross-origin isolated
-        capability=].
+        an appropriate base for comparison, create [=moments=] using an
+        [=environment settings object=]'s [=environment settings object/current
+        monotonic time=]. An [=environment settings object=] |settingsObject|'s
+        <dfn data-export data-dfn-for="environment settings object">current
+        monotonic time</dfn> is the result of the following steps:
       </p>
+      <ol>
+        <li>
+          Let |unsafeMonotonicTime| be the [=monotonic clock=]'s [=monotonic
+          clock/unsafe current time=].
+        </li>
+        <li>
+          Return the result of calling [=coarsen time=] with
+          |unsafeMonotonicTime| and |settingsObject|'s [=environment settings
+          object/cross-origin isolated capability=].
+        </li>
+      </ol>
       <p>
         [=Moments=] from the [=monotonic clock=] can't be directly represented
-        in Javascript or HTTP. Instead, expose a [=duration=] between two such
+        in JavaScript or HTTP. Instead, expose a [=duration=] between two such
         [=moments=].
       </p>
       <p>
         For measuring time across multiple UA executions, create [=moments=]
-        using a |settingsObject|'s <dfn data-export
-        data-dfn-for="environment settings object">current wall time</dfn>,
-        defined as [=coarsen time=] applied to the [=wall clock=]'s [=wall
-        clock/unsafe current time=] and |settingsObject|'s [=environment
-        settings object/cross-origin isolated capability=].
+        using an [=environment settings object=]'s [=environment settings
+        object/current wall time=]. An [=environment settings object=]
+        |settingsObject|'s <dfn data-export
+        data-dfn-for="environment settings object">current wall time</dfn> is
+        the result of the following steps:
       </p>
+      <ol>
+        <li>
+          Let |unsafeWallTime| be the [=wall clock=]'s [=wall clock/unsafe
+          current time=].
+        </li>
+        <li>
+          Return the result of calling [=coarsen time=] with |unsafeWallTime|
+          and |settingsObject|'s [=environment settings object/cross-origin
+          isolated capability=].
+        </li>
+      </ol>
       <p class="advisement">
         When using [=moments=] from the [=wall clock=], be sure that your design
-        does something reasonable when the user adjusts their clock either
-        forward or backward.
+        accounts for situations when the user adjusts their clock either forward
+        or backward.
       </p>
       <p>
-        [=Moments=] from the [=wall clock=] can be represented in Javascript by
+        [=Moments=] from the [=wall clock=] can be represented in JavaScript by
         passing the number of milliseconds from the [=Unix epoch=] to that
         [=moment=] into the {{Date}} constructor, or by passing the number of
         nanoseconds from the [=Unix epoch=] to that [=moment=] into the

--- a/index.html
+++ b/index.html
@@ -378,7 +378,7 @@
         data-cite="Temporal#sec-temporal-instant-constructor">Temporal.Instant</a>
         constructor.
       </p>
-      <p class="advisement" data-tracking-vector>
+      <p class="advisement tracking-vector">
         Avoid sending similar representations between computers, as doing so
         will expose the user's clock skew, which is a [=tracking vector=].
         Instead, use an approach similar to [=monotonic clock=] [=moments=] of

--- a/index.html
+++ b/index.html
@@ -231,17 +231,112 @@
       </pre>
       </section>
     </section>
+    <section id="sec-concepts">
+      <h3>
+        Time Concepts
+      </h3>
+      <section id="sec-clocks">
+        <h4>
+          Clocks
+        </h4>
+        <p>
+          A <dfn>clock</dfn> tracks the passage of time and can report the
+          <dfn>current time</dfn> that an algorithm step is executing. There are
+          many kinds of clocks. All clocks on the web platform attempt to count
+          1 millisecond of clock time per 1 millisecond of real-world time, but
+          they differ in how they handle cases where they can't be exactly
+          correct.
+        </p>
+        <ul>
+          <li>The <dfn data-export>wall clock</dfn>'s <dfn data-dfn-for="wall clock"
+          data-export>current time</dfn>
+          is always as close as possible to a human user's notion of time. Since a
+          computer sometimes runs slow or fast or loses track of time, its [=wall
+          clock=] sometimes needs to be adjusted, which means the [=wall
+          clock/current time=] can decrease, making it unreliable for performance
+          measurement or recording the orders of events. [[ECMA-262]] <dfn
+          data-no-export="" data-cite=
+          "ECMA-262#sec-time-values-and-time-range">time</dfn> is a [=wall
+          clock=].</li>
+
+          <li>A <dfn data-export>monotonic clock</dfn>'s current time never
+          decreases, so it can't be changed by system clock adjustments. There are
+          several kinds of [=monotonic clock=] varying by the point in time they
+          assign to 0, whether they pause while the computer is asleep, and whether
+          their speed adjusts to keep them close to the [=wall clock=].</li>
+
+          <li>
+            <p>
+              The <dfn>shared monotonic clock</dfn> is a [=monotonic clock=]
+              that's shared between all [=browsing contexts=] that can communicate
+              with each other. Its <dfn data-export data-dfn-for="shared monotonic
+              clock">current time</dfn> will advance monotonically and be comparable
+              across all of those browsing contexts.
+            </p>
+            <p class="note">
+              The user agent can reset its <a>shared monotonic clock</a> across
+              browser restarts, or whenever starting an isolated browsing
+              session—e.g. incognito or similar browsing mode. As a result,
+              developers should not use shared timestamps as absolute time that holds
+              its monotonic properties across all past, present, and future contexts;
+              in practice, the monotonic properties only apply for contexts that can
+              reach each other by exchanging messages via one of the provided
+              messaging mechanisms - e.g. `postMessage`, `BroadcastChannel`, etc.
+            </p>
+            <p class="note">
+              In certain scenarios (e.g. when a tab is backgrounded), the user agent
+              may choose to throttle timers and periodic callbacks run in that
+              context or even freeze them entirely. Any such throttling should not
+              affect the resolution or accuracy of the time returned by the monotonic
+              clock.
+            </p>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h4>
+          Instants and Durations
+        </h4>
+        <p>
+          Each [=clock=]'s [=current time=] returns an <dfn>unsafe
+          instant</dfn>. [=Coarsen time=] converts these [=unsafe instants=] to
+          <dfn data-export data-lt="instant">coarsened instants</dfn> or just
+          [=instants=]. [=Unsafe instants=] and [=instants=] from different
+          clocks are not comparable.
+        </p>
+        <p>
+          A <dfn data-export>duration</dfn> is the distance from one [=instant=]
+          to another [=instant=] from the same [=clock=]. One of the two
+          instants can also be an [=unsafe instant=]. [=Durations=] are measured
+          in milliseconds, seconds, etc. Since all [=clocks=] attempt to count
+          at the same rate, [=durations=] don't have an associated [=clock=],
+          and a [=duration=] calculated from two [=instants=] on one clock can
+          be added to an [=instant=] from a second [=clock=], to produce another
+          [=instant=] on that second [=clock=].
+        </p>
+      </section>
+    </section>
     <section id="sec-time-origin">
       <h3>
         Time Origin
       </h3>
       <p>
-        The <dfn data-export="">time origin</dfn> is the time value from which
-        time is measured:
+        An invocation of the [=user agent=] has a <dfn>shared time origin wall
+        time</dfn> and a <dfn>shared time origin monotonic time</dfn>, whose
+        values are initialized from the [=wall clock=]'s [=wall clock/current
+        time=] and the [=shared monotonic clock=]'s [=shared monotonic
+        clock/current time=], respectively, measured as close together as possible.
+      </p>
+      <p>
+        Performance measurements report a [=duration=] on the [=shared monotonic
+        clock=] from an [=instant=] early in the initialization of a relevant
+        [=environment settings object=]. That [=instant=] is stored in that
+        settings object's [=environment settings object/time origin=].
       </p>
       <p>
         To <dfn>get time origin timestamp</dfn>, given a [=/global object=]
-        |global|, runs the following steps:
+        |global|, run the following steps, which return an [=instant=] on the
+        [=wall clock=]:
       </p>
       <ol>
         <li>
@@ -256,15 +351,11 @@
             [=run a worker|worker is run=]. [[service-workers]]
           </p>
         </li>
-        <li>Let <var>t1</var> be the {{DOMHighResTimeStamp}} representing the
-        high resolution time at which the <a>shared monotonic clock</a> is
-        zero.
+        <li>Let <var>delta</var> be the [=duration=] from the [=shared time
+        origin monotonic time=] to |timeOrigin|.
         </li>
-        <li>Let <var>t2</var> be the {{DOMHighResTimeStamp}} representing the
-        high resolution time value of the <a>shared monotonic clock</a> at
-        <var>timeOrigin</var>.
-        </li>
-        <li>Let |total| be the sum of <var>t1</var> and <var>t2</var>.
+        <li>Let |total| be the sum of the [=shared time origin wall time=] and
+        |delta|.
         </li>
         <li>Return the result of calling [=coarsen time=] with |total| and
         |global|'s [=relevant settings object=]'s [=environment settings
@@ -272,17 +363,16 @@
         </li>
       </ol>
       <p class="note">
-        The value returned by [=get time origin timestamp=] is the high
-        resolution time value at which <a>time origin</a> is zero. It may
-        differ from the value returned by <a>Date.now()</a> executed at "zero
-        time", because the former is recorded with respect to a <a>shared
-        monotonic clock</a> that is not subject to system and user clock
-        adjustments, clock skew, and so on — see <a href=
-        "#sec-monotonic-clock"></a>.
+        The value returned by [=get time origin timestamp=] is the [=wall
+        clock=] time value at |global|'s [=environment settings object/time
+        origin=]. It may differ from the value returned by <a>Date.now()</a>
+        executed at the time origin, because the former is recorded with respect
+        to a <a>shared monotonic clock</a> that is not subject to system and
+        user clock adjustments, clock skew, and so on.
       </p>
       <div data-algorithm="coarsen time">
-        The <dfn data-export="">coarsen time</dfn> algorithm, given a
-        {{DOMHighResTimeStamp}} |timestamp| and an optional boolean
+        The <dfn data-export="">coarsen time</dfn> algorithm, given an [=unsafe instant=]
+        |timestamp| on some [=clock=] and an optional boolean
         |crossOriginIsolatedCapability| (default false), runs the following
         steps:
         <ol>
@@ -297,7 +387,7 @@
           potentially jitter |timestamp| such that its resolution will not
           exceed |time resolution|.
           </li>
-          <li>Return |timestamp|.
+          <li>Return |timestamp| as an [=instant=].
           </li>
         </ol>
       </div>
@@ -413,6 +503,15 @@
           The <dfn>now()</dfn> method MUST return the <a>current high
           resolution time</a>.
         </p>
+        <p data-tests=
+          "monotonic-clock.any.html, monotonic-clock.any.worker.html">
+          The time values returned when calling the {{Performance/now()}} method
+          on {{Performance}} objects with the same <a>time origin</a> MUST use the
+          same [=monotonic clock=]. The difference between any two chronologically
+          recorded time values returned from the {{Performance/now()}} method MUST
+          never be negative if the two time values have the same <a>time
+          origin</a>.
+        </p>
       </section>
       <section>
         <h3>
@@ -422,6 +521,14 @@
           The <dfn>timeOrigin</dfn> attribute MUST return the value returned by
           [=get time origin timestamp=] for the <a>relevant global object</a>
           of [=this=].
+        </p>
+        <p data-tests="test_cross_frame_start.html">
+          The time values returned when getting
+          {{Performance}}.{{Performance/timeOrigin}} MUST use the same [=shared
+          monotonic clock=] that is shared by <a>time origin</a>s, and whose
+          reference point is the [[ECMA-262]] <a data-cite=
+          "ECMA-262#sec-time-values-and-time-range">time</a> definition - see
+          [[[#sec-security]]].
         </p>
       </section>
       <section>
@@ -453,49 +560,6 @@
       };
   </pre>
       </section>
-    </section>
-    <section id="sec-monotonic-clock">
-      <h3>
-        Monotonic Clock
-      </h3>
-      <p data-tests=
-      "monotonic-clock.any.html, monotonic-clock.any.worker.html">
-        The time values returned when calling the {{Performance/now()}} method
-        on {{Performance}} objects with the same <a>time origin</a> MUST use
-        the same <dfn data-export="">monotonic clock</dfn> that is
-        monotonically increasing and not subject to system clock adjustments or
-        system clock skew. The difference between any two chronologically
-        recorded time values returned from the {{Performance/now()}} method
-        MUST never be negative if the two time values have the same <a>time
-        origin</a>.
-      </p>
-      <p data-tests="test_cross_frame_start.html">
-        The time values returned when getting
-        {{Performance}}.{{Performance/timeOrigin}} MUST use the same
-        <dfn>shared monotonic clock</dfn> that is shared by <a>time
-        origin</a>s, is monotonically increasing and not subject to system
-        clock adjustments or system clock skew, and whose reference point is
-        the [[ECMA-262]] <dfn data-no-export="" data-cite=
-        "ECMA-262#sec-time-values-and-time-range">time</dfn> definition - see
-        [[[#sec-security]]].
-      </p>
-      <p class="note">
-        The user agent can reset its <a>shared monotonic clock</a> across
-        browser restarts, or whenever starting an isolated browsing
-        session—e.g. incognito or similar browsing mode. As a result,
-        developers should not use shared timestamps as absolute time that holds
-        its monotonic properties across all past, present, and future contexts;
-        in practice, the monotonic properties only apply for contexts that can
-        reach each other by exchanging messages via one of the provided
-        messaging mechanisms - e.g. `postMessage`, `BroadcastChannel`, etc.
-      </p>
-      <p class="note">
-        In certain scenarios (e.g. when a tab is backgrounded), the user agent
-        may choose to throttle timers and periodic callbacks run in that
-        context or even freeze them entirely. Any such throttling should not
-        affect the resolution or accuracy of the time returned by the monotonic
-        clock.
-      </p>
     </section>
     <section id="sec-security">
       <h3>

--- a/index.html
+++ b/index.html
@@ -178,9 +178,9 @@
         <p>
           A developer may wish to construct a timeline of their entire
           application, including events from {{Worker}} or {{SharedWorker}},
-          which have different <a>time origin</a>s. To display such events on
-          the same timeline, the application can translate the
-          {{DOMHighResTimeStamp}}s with the help of the
+          which have different [=environment settings object/time origins=]. To
+          display such events on the same timeline, the application can
+          translate the {{DOMHighResTimeStamp}}s with the help of the
           {{Performance}}.{{Performance/timeOrigin}} attribute.
         </p>
         <pre class="example js">
@@ -250,31 +250,27 @@
         <ul>
           <li>The <dfn data-export>wall clock</dfn>'s <dfn data-dfn-for="wall clock"
           data-export>current time</dfn>
-          is always as close as possible to a human user's notion of time. Since a
-          computer sometimes runs slow or fast or loses track of time, its [=wall
-          clock=] sometimes needs to be adjusted, which means the [=wall
-          clock/current time=] can decrease, making it unreliable for performance
-          measurement or recording the orders of events. [[ECMA-262]] <dfn
+          is always as close as possible to a human user's notion of time. Since
+          a computer sometimes runs slow or fast or loses track of time, its
+          [=wall clock=] sometimes needs to be adjusted, which means the [=wall
+          clock/current time=] can decrease, making it unreliable for
+          performance measurement or recording the orders of events. The web
+          platform shares a [=wall clock=] with [[ECMA-262]] <dfn
           data-no-export="" data-cite=
-          "ECMA-262#sec-time-values-and-time-range">time</dfn> is a [=wall
-          clock=].</li>
-
-          <li>A <dfn data-export>monotonic clock</dfn>'s current time never
-          decreases, so it can't be changed by system clock adjustments. There are
-          several kinds of [=monotonic clock=] varying by the point in time they
-          assign to 0, whether they pause while the computer is asleep, and whether
-          their speed adjusts to keep them close to the [=wall clock=].</li>
+          "ECMA-262#sec-time-values-and-time-range">time</dfn>.</li>
 
           <li>
             <p>
-              The <dfn>shared monotonic clock</dfn> is a [=monotonic clock=]
-              that's shared between all [=browsing contexts=] that can communicate
-              with each other. Its <dfn data-export data-dfn-for="shared monotonic
-              clock">current time</dfn> will advance monotonically and be comparable
-              across all of those browsing contexts.
+              The <dfn data-export>monotonic clock</dfn>'s <dfn data-export
+              data-dfn-for="monotonic clock">current time</dfn> never decreases,
+              so it can't be changed by system clock adjustments. It only exists
+              within a single execution of the [=user agent=], so it can't be
+              used to compare events that might happen in different executions.
+              Since it can't be adjusted to match the user's notion of time,
+              it's also not appropriate for communicating with the user.
             </p>
             <p class="note">
-              The user agent can reset its <a>shared monotonic clock</a> across
+              The user agent can reset its <a>monotonic clock</a> across
               browser restarts, or whenever starting an isolated browsing
               session—e.g. incognito or similar browsing mode. As a result,
               developers should not use shared timestamps as absolute time that holds
@@ -321,14 +317,18 @@
         Time Origin
       </h3>
       <p>
-        An invocation of the [=user agent=] has a <dfn>shared time origin wall
-        time</dfn> and a <dfn>shared time origin monotonic time</dfn>, whose
-        values are initialized from the [=wall clock=]'s [=wall clock/current
-        time=] and the [=shared monotonic clock=]'s [=shared monotonic
-        clock/current time=], respectively, measured as close together as possible.
+        Each group of [=environment settings objects=] that could possibly
+        communicate in any way has a <dfn>shared time origin wall time</dfn> and
+        a <dfn>shared time origin monotonic time</dfn>, whose values are
+        initialized from the [=wall clock=]'s [=wall clock/current time=] and
+        the [=monotonic clock=]'s [=monotonic clock/current time=],
+        respectively, measured as close together as possible. <span
+        class="issue">This set of settings objects needs to be specified better.
+        It's similar to <a data-cite="html/browsers.html#familiar-with">familiar
+        with</a> but includes {{Worker}}s.</span>
       </p>
       <p>
-        Performance measurements report a [=duration=] on the [=shared monotonic
+        Performance measurements report a [=duration=] on the [=monotonic
         clock=] from an [=instant=] early in the initialization of a relevant
         [=environment settings object=]. That [=instant=] is stored in that
         settings object's [=environment settings object/time origin=].
@@ -367,8 +367,8 @@
         clock=] time value at |global|'s [=environment settings object/time
         origin=]. It may differ from the value returned by <a>Date.now()</a>
         executed at the time origin, because the former is recorded with respect
-        to a <a>shared monotonic clock</a> that is not subject to system and
-        user clock adjustments, clock skew, and so on.
+        to a <a>monotonic clock</a> that is not subject to system and user clock
+        adjustments, clock skew, and so on.
       </p>
       <div data-algorithm="coarsen time">
         The <dfn data-export="">coarsen time</dfn> algorithm, given an [=unsafe instant=]
@@ -422,7 +422,7 @@
       </p>
       <p>
         The <dfn data-export="">unsafe shared current time</dfn> must return
-        the current value of the <a>shared monotonic clock</a>.
+        the current value of the <a>monotonic clock</a>.
       </p>
       <p>
         To get an <dfn data-export="">epoch-relative timestamp</dfn>,
@@ -446,9 +446,10 @@
       </h3>
       <p>
         The {{DOMHighResTimeStamp}} type is used to store a time value in
-        milliseconds, measured relative from the <a>time origin</a>, <a>shared
-        monotonic clock</a>, or a time value that represents a duration between
-        two {{DOMHighResTimeStamp}}s.
+        milliseconds, measured relative from a [=environment settings
+        object/time origin=],
+        <a>monotonic clock</a>, or a time value that represents a duration
+        between two {{DOMHighResTimeStamp}}s.
       </p>
       <pre class="idl">
       typedef double DOMHighResTimeStamp;
@@ -506,11 +507,12 @@
         <p data-tests=
           "monotonic-clock.any.html, monotonic-clock.any.worker.html">
           The time values returned when calling the {{Performance/now()}} method
-          on {{Performance}} objects with the same <a>time origin</a> MUST use the
-          same [=monotonic clock=]. The difference between any two chronologically
-          recorded time values returned from the {{Performance/now()}} method MUST
-          never be negative if the two time values have the same <a>time
-          origin</a>.
+          on {{Performance}} objects with the same [=environment settings
+          object/time origin=] MUST use the same [=monotonic clock=]. The
+          difference between any two chronologically recorded time values
+          returned from the {{Performance/now()}} method MUST never be negative
+          if the two time values have the same [=environment settings
+          object/time origin=].
         </p>
       </section>
       <section>
@@ -524,11 +526,11 @@
         </p>
         <p data-tests="test_cross_frame_start.html">
           The time values returned when getting
-          {{Performance}}.{{Performance/timeOrigin}} MUST use the same [=shared
-          monotonic clock=] that is shared by <a>time origin</a>s, and whose
-          reference point is the [[ECMA-262]] <a data-cite=
-          "ECMA-262#sec-time-values-and-time-range">time</a> definition - see
-          [[[#sec-security]]].
+          {{Performance}}.{{Performance/timeOrigin}} MUST use the same
+          [=monotonic clock=] that is shared by [=environment settings
+          object/time origins=], and whose reference point is the [[ECMA-262]]
+          <a data-cite= "ECMA-262#sec-time-values-and-time-range">time</a>
+          definition - see [[[#sec-security]]].
         </p>
       </section>
       <section>
@@ -652,29 +654,29 @@
         <p>
           This specification also defines an API that provides sub-millisecond
           time resolution of the zero time of the time origin, which requires
-          and exposes a <a>shared monotonic clock</a> to the application, and
-          that must be shared across all the browser contexts. The <a>shared
-          monotonic clock</a> does not need to be tied to physical time, but is
-          recommended to be set with respect to the [[ECMA-262]] definition of
+          and exposes a <a>monotonic clock</a> to the application, and that must
+          be shared across all the browser contexts. The <a>monotonic clock</a>
+          does not need to be tied to physical time, but is recommended to be
+          set with respect to the [[ECMA-262]] definition of
           <a>time</a> to avoid exposing new fingerprint entropy about the user
           — e.g. this time can already be easily obtained by the application,
           whereas exposing a new logical clock provides new information.
         </p>
         <p>
-          However, even with the above mechanism in place, the <a>shared
-          monotonic clock</a> may provide additional <a href=
+          However, even with the above mechanism in place, the <a>monotonic
+          clock</a> may provide additional <a href=
           "https://en.wikipedia.org/wiki/Clock_drift">clock drift</a>
           resolution. Today, the application can timestamp the time-of-day and
           monotonic time values (via <a>Date.now()</a> and
           {{Performance/now()}}) at multiple points within the same context and
           observe drift between them—e.g. due to automatic or user clock
           adjustments. With the {{Performance/timeOrigin}} attribute, the
-          attacker can also compare the time at which <a>time origin</a> is
-          zero, as reported by the <a>shared monotonic clock</a>, against the
-          current time-of-day estimate of when it is zero (i.e. the difference
-          between `Date.now() - performance.now()` and
-          `performance.timeOrigin`) and potentially observe clock drift between
-          these clocks over a longer time period.
+          attacker can also compare the [=environment settings object/time
+          origin=], as reported by the <a>monotonic clock</a>, against the
+          current time-of-day estimate of the [=environment settings object/time
+          origin=] (i.e. the difference between `performance.timeOrigin` and
+          `Date.now() - performance.now()`) and potentially observe clock drift
+          between these clocks over a longer time period.
         </p>
         <p>
           In practice, the same time drift can be observed by an application
@@ -694,7 +696,8 @@
         Privacy Considerations
       </h3>
       <p>
-        The current definition of [=time origin=] for a {{Document}} exposes
+        The current definition of [=environment settings object/time origin=]
+        for a {{Document}} exposes
         the total time of cross-origin redirects prior to the request arriving
         at the document's origin. This exposes cross-origin information,
         however it's not yet decided how to mitigate this without causing major

--- a/index.html
+++ b/index.html
@@ -272,11 +272,12 @@
             <p>
               The <dfn data-export>monotonic clock</dfn>'s <dfn data-export
               data-dfn-for="monotonic clock">unsafe current time</dfn> never decreases,
-              so it can't be changed by system clock adjustments. It only exists
-              within a single execution of the [=user agent=], so it can't be
-              used to compare events that might happen in different executions.
-              Since it can't be adjusted to match the user's notion of time,
-              it's also not appropriate for communicating with the user.
+              so it can't be changed by system clock adjustments. The
+              [=monotonic clock=] only exists within a single execution of the
+              [=user agent=], so it can't be used to compare events that might
+              happen in different executions. Since it can't be adjusted to
+              match the user's notion of time, it's also not appropriate for
+              communicating with the user.
             </p>
             <p class="note">
               The user agent can pick a new [=estimated monotonic time of the

--- a/index.html
+++ b/index.html
@@ -314,14 +314,27 @@
         </p>
         <p>
           A <dfn data-export>duration</dfn> is the distance from one [=moment=]
-          to another [=moment=] from the same [=clock=]. One of the two
-          moments can also be an [=unsafe moment=]. [=Durations=] are measured
+          or [=unsafe moment=] to another from the same [=clock=]. At most one
+          of the endpoints can be an [=unsafe moment=] in order to ensure that
+          all [=durations=] mitigate the concerns in [[[#clock-resolution]]].
+          [=Durations=] are measured
           in milliseconds, seconds, etc. Since all [=clocks=] attempt to count
           at the same rate, [=durations=] don't have an associated [=clock=],
           and a [=duration=] calculated from two [=moments=] on one clock can
           be added to a [=moment=] from a second [=clock=], to produce another
           [=moment=] on that second [=clock=].
         </p>
+        <p>
+          The <dfn data-export>duration from</dfn> |a:moment| to |b:moment| is the result of
+          the following algorithm:
+        </p>
+        <ol class="algorithm">
+          <li>Assert: |a| was created by the same [=clock=] as |b|.</li>
+          <li>Assert: At least one of |a| or |b| is a [=coarsened moment=].
+          Equivalently, at most one is an [=unsafe moment=].</li>
+          <li>Return the amount of time from |a| to |b| as a [=duration=]. If
+          |b| came before |a|, this will be a negative [=duration=].</li>
+        </ol>
         <p>
           [=Durations=] can be used implicitly as {{DOMHighResTimeStamp}}s. To
           <dfn>implicitly convert a duration to a timestamp</dfn>, given a

--- a/index.html
+++ b/index.html
@@ -257,7 +257,8 @@
           performance measurement or recording the orders of events. The web
           platform shares a [=wall clock=] with [[ECMA-262]] <dfn
           data-no-export="" data-cite=
-          "ECMA-262#sec-time-values-and-time-range">time</dfn>.</li>
+          "ECMA-262#sec-time-values-and-time-range">time</dfn>.
+          </li>
 
           <li>
             <p>
@@ -307,7 +308,7 @@
           in milliseconds, seconds, etc. Since all [=clocks=] attempt to count
           at the same rate, [=durations=] don't have an associated [=clock=],
           and a [=duration=] calculated from two [=moments=] on one clock can
-          be added to an [=moment=] from a second [=clock=], to produce another
+          be added to a [=moment=] from a second [=clock=], to produce another
           [=moment=] on that second [=clock=].
         </p>
       </section>
@@ -317,26 +318,41 @@
         Time Origin
       </h3>
       <p>
-        Each group of [=environment settings objects=] that could possibly
-        communicate in any way has a <dfn>shared time origin wall time</dfn> and
-        a <dfn>shared time origin monotonic time</dfn>, whose values are
-        initialized from the [=wall clock=]'s [=wall clock/current time=] and
-        the [=monotonic clock=]'s [=monotonic clock/current time=],
-        respectively, measured as close together as possible. <span
-        class="issue">This set of settings objects needs to be specified better.
-        It's similar to <a data-cite="html/browsers.html#familiar-with">familiar
-        with</a> but includes {{Worker}}s.</span>
+        The <dfn data-export>Unix epoch</dfn> is the [=moment=] on the [=wall
+        clock=] corresponding to 1 January 1970 00:00:00 UTC.
       </p>
       <p>
-        Performance measurements report a [=duration=] on the [=monotonic
-        clock=] from an [=moment=] early in the initialization of a relevant
-        [=environment settings object=]. That [=moment=] is stored in that
-        settings object's [=environment settings object/time origin=].
+        Each group of [=environment settings objects=] that could possibly
+        communicate in any way has an <dfn>estimated monotonic time of the Unix
+        epoch</dfn>, an [=unsafe moment=] on the [=monotonic clock=], whose
+        value is initialized by the following steps:
+      </p>
+      <ol data-algorithm=
+      "initialize the estimated monotonic time of the Unix epoch">
+        <li>Let |wall time| be the [=wall clock=]'s [=wall clock/current
+        time=].
+        </li>
+        <li>Let |monotonic time| be the [=monotonic clock=]'s [=monotonic
+        clock/current time=].
+        </li>
+        <li>Initialize the [=estimated monotonic time of the Unix epoch=] to
+        <code>|monotonic time| - (|wall time| - [=Unix epoch=])</code>.
+        </li>
+      </ol>
+      <div class="issue">
+        The above set of settings objects needs to be specified better. It's
+        similar to <a data-cite="html/browsers.html#familiar-with">familiar
+        with</a> but includes {{Worker}}s.
+      </div>
+      <p>
+        Performance measurements report a [=duration=] from a [=moment=] early
+        in the initialization of a relevant [=environment settings object=].
+        That [=moment=] is stored in that settings object's [=environment
+        settings object/time origin=].
       </p>
       <p>
         To <dfn>get time origin timestamp</dfn>, given a [=/global object=]
-        |global|, run the following steps, which return an [=moment=] on the
-        [=wall clock=]:
+        |global|, run the following steps, which return a [=duration=]:
       </p>
       <ol>
         <li>
@@ -351,21 +367,15 @@
             [=run a worker|worker is run=]. [[service-workers]]
           </p>
         </li>
-        <li>Let <var>delta</var> be the [=duration=] from the [=shared time
-        origin monotonic time=] to |timeOrigin|.
-        </li>
-        <li>Let |total| be the sum of the [=shared time origin wall time=] and
-        |delta|.
-        </li>
-        <li>Return the result of calling [=coarsen time=] with |total| and
-        |global|'s [=relevant settings object=]'s [=environment settings
-        object/cross-origin isolated capability=].
+        <li>Return the [=duration=] from the [=estimated monotonic time of the
+        Unix epoch=] to |timeOrigin|.
         </li>
       </ol>
       <p class="note">
-        The value returned by [=get time origin timestamp=] is the [=wall
-        clock=] time value at |global|'s [=environment settings object/time
-        origin=]. It may differ from the value returned by <a>Date.now()</a>
+        The value returned by [=get time origin timestamp=] is approximately the
+        time after the [=Unix epoch=] that |global|'s [=environment settings
+        object/time origin=] happened. It may differ from the value returned by
+        <a>Date.now()</a>
         executed at the time origin, because the former is recorded with respect
         to a <a>monotonic clock</a> that is not subject to system and user clock
         adjustments, clock skew, and so on.
@@ -387,14 +397,15 @@
           potentially jitter |timestamp| such that its resolution will not
           exceed |time resolution|.
           </li>
-          <li>Return |timestamp| as an [=moment=].
+          <li>Return |timestamp| as a [=moment=].
           </li>
         </ol>
       </div>
       <div data-algorithm="relative high resolution time">
-        The <dfn data-export="">relative high resolution time</dfn> given a
-        {{DOMHighResTimeStamp}} |time| and a [=Realm/global object=] |global|,
-        is the result of the following steps:
+        The <dfn data-export="">relative high resolution time</dfn> given an
+        [=unsafe moment=] from the [=monotonic clock=] |time| and a
+        [=Realm/global object=] |global|, is the [=duration=] returned from the
+        following steps:
         <ol>
           <li>Let |coarse time| be the result of calling [=coarsen time=] with
           |time| and |global|'s [=relevant settings object=]'s [=environment
@@ -404,9 +415,10 @@
           time| and |global|.
           </li>
         </ol>The <dfn data-export="">relative high resolution coarse time</dfn>
-        given a {{DOMHighResTimeStamp}} |coarseTime| and a [=Realm/global
-        object=] |global|, is the difference between |coarseTime| and the
-        result of calling [=get time origin timestamp=] with |global|.
+        given a [=moment=] from the [=monotonic clock=] |coarseTime| and a
+        [=Realm/global object=] |global|, is the [=duration=] from |global|'s
+        [=relevant settings object=]'s [=environment settings object/time
+        origin=] to |coarseTime|.
       </div>
       <p>
         The <dfn data-export="">current high resolution time</dfn> given a
@@ -422,21 +434,22 @@
       </p>
       <p>
         The <dfn data-export="">unsafe shared current time</dfn> must return
-        the current value of the <a>monotonic clock</a>.
+        the [=monotonic clock/current time=] of the <a>monotonic clock</a>.
       </p>
       <p>
         To get an <dfn data-export="">epoch-relative timestamp</dfn>,
-        optionally with a date-time |time|:
+        optionally with a [=moment=] on the [=wall clock=] |time|:
       </p>
       <ol class="algorithm">
-        <li>If |time| was not passed, set |time| to the current time.
+        <li>If |time| was not passed, set |time| to the [=wall clock=]'s [=wall
+        clock/current time=].
         </li>
         <li>Assert: |time| is greater than or equal to 1 January 1970 00:00:00
         UTC.
         </li>
-        <li>Return the number of milliseconds from 1 January 1970 00:00:00 UTC
-        to |time|: where each day is comprised of 86,400 seconds, each of which
-        is 1000 milliseconds long (i.e., don't account for leap seconds).
+        <li>Return the number of milliseconds from the [=Unix epoch=] to |time|:
+        where each day is comprised of 86,400 seconds, each of which is 1000
+        milliseconds long (i.e., don't account for leap seconds).
         </li>
       </ol>
     </section>
@@ -445,11 +458,10 @@
         The <dfn data-export="">DOMHighResTimeStamp</dfn> typedef
       </h3>
       <p>
-        The {{DOMHighResTimeStamp}} type is used to store a time value in
-        milliseconds, measured relative from a [=environment settings
-        object/time origin=],
-        <a>monotonic clock</a>, or a time value that represents a duration
-        between two {{DOMHighResTimeStamp}}s.
+        The {{DOMHighResTimeStamp}} type is used to store a [=duration=] in
+        milliseconds. Depending on its context, it may represent the [=moment=]
+        that is this [=duration=] after a base [=moment=] like a
+        [=environment settings object/time origin=] or the [=Unix epoch=].
       </p>
       <pre class="idl">
       typedef double DOMHighResTimeStamp;
@@ -480,8 +492,8 @@
         are interpreted. An {{EpochTimeStamp}} is initialized by calling
         [=epoch-relative timestamp=] with no arguments, which defaults to the
         current time. Specifications that require a different relative time can
-        call [=epoch-relative timestamp=] with a date-time as an argument, if
-        needed.
+        call [=epoch-relative timestamp=] with a [=moment=] from the [=wall
+        clock=] as an argument, if needed.
       </p>
     </section>
     <section id="sec-performance" data-dfn-for="Performance">
@@ -501,8 +513,8 @@
           `now()` method
         </h3>
         <p data-tests="basic.any.html, basic.any.worker.html">
-          The <dfn>now()</dfn> method MUST return the <a>current high
-          resolution time</a>.
+          The <dfn>now()</dfn> method MUST return the number of milliseconds in
+          the <a>current high resolution time</a> (a [=duration=]).
         </p>
         <p data-tests=
           "monotonic-clock.any.html, monotonic-clock.any.worker.html">
@@ -520,8 +532,9 @@
           `timeOrigin` attribute
         </h3>
         <p data-tests="timeOrigin.html, window-worker-timeOrigin.window.html">
-          The <dfn>timeOrigin</dfn> attribute MUST return the value returned by
-          [=get time origin timestamp=] for the <a>relevant global object</a>
+          The <dfn>timeOrigin</dfn> attribute MUST return the number of
+          milliseconds in the [=duration=] returned by [=get time origin
+          timestamp=] for the <a>relevant global object</a>
           of [=this=].
         </p>
         <p data-tests="test_cross_frame_start.html">


### PR DESCRIPTION
I believe this fixes #139.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#sec-concepts, #sec-tools, #sec-time-origin, #sec-domhighrestimestamp, #the-epochtimestamp-typedef, #sec-performance, #clock-drift
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html" title="Last updated on Jan 12, 2023, 3:15 PM UTC (2c194b4)">Preview</a> (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#sec-concepts" title="#sec-concepts">#sec-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#sec-tools" title="#sec-tools">#sec-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#sec-time-origin" title="#sec-time-origin">#sec-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#sec-domhighrestimestamp" title="#sec-domhighrestimestamp">#sec-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#the-epochtimestamp-typedef" title="#the-epochtimestamp-typedef">#the-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#sec-performance" title="#sec-performance">#sec-…</a>) (<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/140.html#clock-drift" title="#clock-drift">#cloc…</a>) | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/140/f1fd2aa...jyasskin:2c194b4.html" title="Last updated on Jan 12, 2023, 3:15 PM UTC (2c194b4)">Diff</a>