### PR TITLE
editorial: Try to explain moments better.

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,11 +317,11 @@
           [=moments=]. [=Unsafe moments=] and [=moments=] from different clocks
           are not comparable.
         </p>
-        <p>
+        <p class="note">
           [=Moments=] and [=unsafe moments=] represent points in time, which
           means they can't be directly stored as numbers. Implementations will
           usually represent a [=moment=] as a [=duration=] from some other fixed
-          point in time, but specifications should deal in the [=moments=]
+          point in time, but specifications ought to deal in the [=moments=]
           themselves.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -318,6 +318,13 @@
           are not comparable.
         </p>
         <p>
+          [=Moments=] and [=unsafe moments=] represent points in time, which
+          means they can't be directly stored as numbers. Implementations will
+          usually represent a [=moment=] as a [=duration=] from some other fixed
+          point in time, but specifications should deal in the [=moments=]
+          themselves.
+        </p>
+        <p>
           A <dfn data-export="">duration</dfn> is the distance from one
           [=moment=] to another from the same [=clock=]. Neither endpoint can
           be an [=unsafe moment=] so that both [=durations=] and differences of


### PR DESCRIPTION
@xyaoinum, does this text help explain what to do with https://github.com/patcg-individual-drafts/topics/pull/93#discussion_r1096846383? There's no implicit "time origin" for moments, so it's not right to assign one to a [DOMHighResTimeStamp](https://w3c.github.io/hr-time/#dom-domhighrestimestamp). Section 3 discusses what to do instead: do you think this text should link directly there?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#moments-and-durations
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/147.html#moments-and-durations" title="Last updated on Feb 7, 2023, 5:51 PM UTC (704622a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/147/4a67828...jyasskin:704622a.html" title="Last updated on Feb 7, 2023, 5:51 PM UTC (704622a)">Diff</a>