### PR TITLE
editorial: Remove the definition of "epoch-relative timestamp".

### DIFF
--- a/index.html
+++ b/index.html
@@ -648,28 +648,6 @@
         the [=monotonic clock/unsafe current time=] of the <a>monotonic
         clock</a>.
       </p>
-      <p>
-        To get an <dfn data-export="">epoch-relative timestamp</dfn>,
-        optionally with a [=moment=] on the [=wall clock=] |time:moment on the
-        wall clock|:
-      </p>
-      <ol class="algorithm">
-        <li>If |time| was not passed, set |time| to the [=wall clock=]'s [=wall
-        clock/unsafe current time=].
-        </li>
-        <li>Assert: |time| is greater than or equal to 1 January 1970 00:00:00
-        UTC.
-        </li>
-        <li>Return the number of milliseconds from the [=Unix epoch=] to
-        |time|: where each day is comprised of 86,400 seconds, each of which is
-        1000 milliseconds long (i.e., don't account for leap seconds).
-        </li>
-      </ol>
-      <p class="note">
-        A {{DOMHighResTimeStamp}} is a double. Therefore, using it to represent
-        an [=epoch-relative timestamp=], e.g. for the purpose of comparing it
-        with <a>Date.now()</a>, might lose sub-millisecond precision.
-      </p>
     </section>
     <section id="sec-domhighrestimestamp">
       <h3>
@@ -704,14 +682,10 @@
         </p>
       </aside>
       <p>
-        A {{EpochTimeStamp}} represents the number of milliseconds from a given
-        time to 01 January, 1970 00:00:00 UTC, excluding leap seconds.
-        Specifications that use this type define how the number of milliseconds
-        are interpreted. An {{EpochTimeStamp}} is initialized by calling
-        [=epoch-relative timestamp=] with no arguments, which defaults to the
-        current time. Specifications that require a different relative time can
-        call [=epoch-relative timestamp=] with a [=moment=] from the [=wall
-        clock=] as an argument, if needed.
+        A {{EpochTimeStamp}} represents an integral number of milliseconds from
+        the [=Unix epoch=] to a given [=moment=] on the [=wall clock=],
+        excluding leap seconds. Specifications that use this type define how the
+        number of milliseconds are interpreted.
       </p>
     </section>
     <section id="sec-performance" data-dfn-for="Performance">

--- a/index.html
+++ b/index.html
@@ -667,6 +667,12 @@
         accurate enough to allow measurement while preventing timing attacks -
         see <a href="#clock-resolution"></a> for additional considerations.
       </p>
+      <p class="note">
+        A {{DOMHighResTimeStamp}} is a {{double}}, so it can only represent an
+        epoch-relative time&mdash;the number of milliseconds from the [=Unix
+        epoch=] to a [=moment=]&mdash;to a finite resolution. For [=moments=] in
+        2023, that resolution is approximately 0.2µs.
+      </p>
     </section>
     <section>
       <h3>

--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@
         A {{DOMHighResTimeStamp}} is a {{double}}, so it can only represent an
         epoch-relative time&mdash;the number of milliseconds from the [=Unix
         epoch=] to a [=moment=]&mdash;to a finite resolution. For [=moments=] in
-        2023, that resolution is approximately 0.2µs.
+        2023, that resolution is approximately 0.2 microseconds.
       </p>
     </section>
     <section>


### PR DESCRIPTION
It was ambiguous about whether it rounded to the nearest integer, and new specifications should use the terms in #sec-tools instead.

https://github.com/whatwg/notifications/pull/192 removes the only use listed in https://dontcallmedom.github.io/webdex/e.html#epoch-relative%20timestamp%40%40hr-time%25%25dfn. If I missed another one, whoever cleans that up can imitate the replacement in that PR or in the #the-epochtimestamp-typedef section here.

----

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

- chore: fixes unrelated to the spec itself (e.g., fix to Github action, html tidy, spec config, etc.). 
- editorial: a non-normative change to the spec (e.g., fixing an example or typo, adding a note).
- change: a normative change to existing engine behavior.
- And use none if it's a new normative requirement. 

If this is a "change", please explain what's significantly changing. 
In particular, if the change results in potential backwards compatibility issues and content breakage, it needs to be justified.

For normative spec changes, please get implementation commitments anf file issues on the various engines during the review process. All tasks should be complete before merging. 

Implementation commitment - primarily for "change" and other normative changes:

- [ ] [WebKit](https://bugs.webkit.org/???)
- [ ] [Chromium](https://bugs.chromium.org/???)
- [ ] [Gecko](http://bugzilla.mozilla.org/???)

Tasks:

- [ ] [Added tests](https://github.com/web-platform-tests/wpt/pulls/???)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/153.html" title="Last updated on Mar 21, 2023, 5:42 PM UTC (20c73a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/153/d925551...jyasskin:20c73a0.html" title="Last updated on Mar 21, 2023, 5:42 PM UTC (20c73a0)">Diff</a>