### PR TITLE
editorial: Add a definition for the "current wall time" without a settings object.

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,11 +398,19 @@
       </p>
       <p>
         For measuring time across multiple UA executions, create [=moments=]
-        using an [=environment settings object=]'s [=environment settings
-        object/current wall time=]. An [=environment settings object=]
-        |settingsObject:environment settings object|'s <dfn data-export=""
-        data-dfn-for="environment settings object">current wall time</dfn> is
-        the result of the following steps:
+        using the [=current wall time=] or (if you need higher precision in
+        [=environment settings object/cross-origin isolated
+        capability|cross-origin-isolated contexts=]) an [=environment settings
+        object=]'s [=environment settings object/current wall time=]. The <dfn
+        data-export="" id="dfn-current-wall-time">current wall time</dfn> is the
+        result of calling [=coarsen time=] with the [=wall clock=]'s [=wall
+        clock/unsafe current time=].
+      </p>
+      <p>
+        An [=environment settings object=] |settingsObject:environment settings
+        object|'s <dfn data-export="" data-dfn-for="environment settings object"
+        id="dfn-eso-current-wall-time">current wall time</dfn> is the result of
+        the following steps:
       </p>
       <ol>
         <li>Let |unsafeWallTime:unsafe moment on the wall clock| be the [=wall


### PR DESCRIPTION
Closes #155

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

- chore: fixes unrelated to the spec itself (e.g., fix to Github action, html tidy, spec config, etc.). 
- editorial: a non-normative change to the spec (e.g., fixing an example or typo, adding a note).
- change: a normative change to existing engine behavior.
- And use none if it's a new normative requirement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#dfn-current-wall-time
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/hr-time/pull/161.html#dfn-current-wall-time" title="Last updated on Apr 24, 2023, 5:56 PM UTC (38b9302)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/161/bf43e1e...jyasskin:38b9302.html" title="Last updated on Apr 24, 2023, 5:56 PM UTC (38b9302)">Diff</a>