### PR TITLE
Add a coarsening function for render timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,6 +621,21 @@
           </li>
         </ol>
       </div>
+      <div data-algorithm="coarsen render time">
+        The <dfn data-export="">coarsen render time</dfn> algorithm, given an [=unsafe
+        moment=] |timestamp:unsafe moment| on some [=clock=] and an optional
+        boolean |crossOriginIsolatedCapability:boolean| (default false), runs
+        the following steps:
+        <ol>
+          <li>If |crossOriginIsolatedCapability| is true, return |timestamp|.
+          </li>
+          <li>In an <a>implementation-defined</a> manner, coarsen and
+          potentially jitter |timestamp| such that its resolution will not
+          exceed 4 milliseconds. To maintain timestamp order, the resulting [=unsafe moment=] must be greater than  the given |timestamp|.
+          </li>
+          <li>Return timestamp.</li>
+          </ol>
+      </div>
       <div data-algorithm="relative high resolution time">
         The <dfn data-export="">relative high resolution time</dfn> given an
         [=unsafe moment=] from the [=monotonic clock=] |time:unsafe moment on


### PR DESCRIPTION
An enabler for https://github.com/w3c/paint-timing/issues/104.
As per the WebPerfWG discussion, this enables exposing coarsened render times for non-TAO cross-origin images.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/166.html" title="Last updated on Nov 4, 2024, 5:28 PM UTC (e6bef53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/166/8558f93...e6bef53.html" title="Last updated on Nov 4, 2024, 5:28 PM UTC (e6bef53)">Diff</a>