### PR TITLE
Rename one of the "current wall time" dfns

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,11 +398,11 @@
       </p>
       <p>
         For measuring time across multiple UA executions, create [=moments=]
-        using the [=current coarsen wall time=] or (if you need higher
+        using the [=current coarsened wall time=] or (if you need higher
         precision in [=environment settings object/cross-origin isolated
         capability|cross-origin-isolated contexts=]) an [=environment settings
         object=]'s [=environment settings object/current wall time=]. The
-        <dfn data-export="" id="dfn-current-wall-time">current coarsen wall
+        <dfn data-export="" id="dfn-current-wall-time">current coarsened wall
         time</dfn> is the result of calling [=coarsen time=] with the [=wall
         clock=]'s [=wall clock/unsafe current time=].
       </p>

--- a/index.html
+++ b/index.html
@@ -398,13 +398,13 @@
       </p>
       <p>
         For measuring time across multiple UA executions, create [=moments=]
-        using the [=current wall time=] or (if you need higher precision in
-        [=environment settings object/cross-origin isolated
+        using the [=current coarsen wall time=] or (if you need higher
+        precision in [=environment settings object/cross-origin isolated
         capability|cross-origin-isolated contexts=]) an [=environment settings
         object=]'s [=environment settings object/current wall time=]. The
-        <dfn data-export="" id="dfn-current-wall-time">current wall time</dfn>
-        is the result of calling [=coarsen time=] with the [=wall clock=]'s
-        [=wall clock/unsafe current time=].
+        <dfn data-export="" id="dfn-current-wall-time">current coarsen wall
+        time</dfn> is the result of calling [=coarsen time=] with the [=wall
+        clock=]'s [=wall clock/unsafe current time=].
       </p>
       <p>
         An [=environment settings object=] |settingsObject:environment settings


### PR DESCRIPTION
Closes #165

This is a non-functional change, to enable distinguishing between the Environment Settings Object's "current wall time" and the equivalent concept that can be used without one.

No implementation commitment or tests are needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/hr-time/pull/167.html" title="Last updated on Nov 7, 2024, 10:40 AM UTC (61fa53d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/167/8558f93...yoavweiss:61fa53d.html" title="Last updated on Nov 7, 2024, 10:40 AM UTC (61fa53d)">Diff</a>