### PR TITLE
change: Update 'relative high resolution time' to use the principal realm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,8 +628,7 @@
         is the [=duration=] returned from the following steps:
         <ol>
           <li>Let |settings:environment settings object| be the |global|'s
-          [=global object/realm=]'s [=realm/principal realm=]'s
-          [=relevant settings object=].
+          [=relevant principal settings object=].
           </li>
           <li>Let |coarse time:moment on the monotonic clock| be the result of
           calling [=coarsen time=] with |time| and |settings|'s
@@ -647,9 +646,8 @@
         is the [=duration=] returned from the following steps:
         <ol>
           <li>Let |settings:environment settings object| be the |global|'s
-            [=global object/realm=]'s [=realm/principal realm=]'s
-            [=relevant settings object=].
-            </li>
+          [=relevant principal settings object=].
+          </li>
           <li>Return the [=duration from=] |settings|'s
           [=environment settings object/time origin=] to |coarseTime|.
           </li>

--- a/index.html
+++ b/index.html
@@ -624,22 +624,36 @@
       <div data-algorithm="relative high resolution time">
         The <dfn data-export="">relative high resolution time</dfn> given an
         [=unsafe moment=] from the [=monotonic clock=] |time:unsafe moment on
-        the monotonic clock| and a [=Realm/global object=] |global:global
-        object|, is the [=duration=] returned from the following steps:
+        the monotonic clock| and a [=global object=] |global:global object|,
+        is the [=duration=] returned from the following steps:
         <ol>
+          <li>Let |settings:environment settings object| be the |global|'s
+          [=global object/realm=]'s [=realm/principal realm=]'s
+          [=relevant settings object=].
+          </li>
           <li>Let |coarse time:moment on the monotonic clock| be the result of
-          calling [=coarsen time=] with |time| and |global|'s [=relevant
-          settings object=]'s [=environment settings object/cross-origin
-          isolated capability=].
+          calling [=coarsen time=] with |time| and |settings|'s
+          [=environment settings object/cross-origin isolated capability=].
           </li>
           <li>Return the [=relative high resolution coarse time=] for |coarse
           time| and |global|.
           </li>
-        </ol>The <dfn data-export="">relative high resolution coarse time</dfn>
+        </ol>
+      </div>
+      <div data-algorithm="relative high resolution coarse time">
+        The <dfn data-export="">relative high resolution coarse time</dfn>
         given a [=moment=] from the [=monotonic clock=] |coarseTime:moment on
-        the monotonic clock| and a [=Realm/global object=] |global:global
-        object|, is the [=duration from=] |global|'s [=relevant settings
-        object=]'s [=environment settings object/time origin=] to |coarseTime|.
+        the monotonic clock| and a [=global object=] |global:global object|,
+        is the [=duration=] returned from the following steps:
+        <ol>
+          <li>Let |settings:environment settings object| be the |global|'s
+            [=global object/realm=]'s [=realm/principal realm=]'s
+            [=relevant settings object=].
+            </li>
+          <li>Return the [=duration from=] |settings|'s
+          [=environment settings object/time origin=] to |coarseTime|.
+          </li>
+        </ol>
       </div>
       <p>
         The <dfn data-export="">current high resolution time</dfn> given a


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/9893.

Closes #???

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

- chore: fixes unrelated to the spec itself (e.g., fix to Github action, html tidy, spec config, etc.). 
- editorial: a non-normative change to the spec (e.g., fixing an example or typo, adding a note).
- change: a normative change to existing engine behavior.
- And use none if it's a new normative requirement. 

If this is a "change", please explain what's significantly changing. 
In particular, if the change results in potential backwards compatibility issues and content breakage, it needs to be justified.

For normative spec changes, please get implementation commitments anf file issues on the various engines during the review process. All tasks should be complete before merging. 

Implementation commitment - primarily for "change" and other normative changes:

- [ ] [WebKit](https://bugs.webkit.org/???)
- [ ] [Chromium](https://bugs.chromium.org/???)
- [ ] [Gecko](http://bugzilla.mozilla.org/???)

Tasks:

- [ ] [Added tests](https://github.com/web-platform-tests/wpt/pulls/???)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/168.html" title="Last updated on Nov 27, 2024, 1:34 PM UTC (be73b36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/168/060b3c9...be73b36.html" title="Last updated on Nov 27, 2024, 1:34 PM UTC (be73b36)">Diff</a>