### PR TITLE
change: Expose Performance interface to AudioWorklet

### DIFF
--- a/index.html
+++ b/index.html
@@ -709,7 +709,7 @@
         The <dfn>Performance</dfn> interface
       </h3>
       <pre class="idl">
-      [Exposed=(Window,Worker)]
+      [Exposed=(Window,Worker,AudioWorklet)]
       interface Performance : EventTarget {
           DOMHighResTimeStamp now();
           readonly attribute DOMHighResTimeStamp timeOrigin;


### PR DESCRIPTION
Closes https://github.com/WebAudio/web-audio-api/issues/2413

The Audio Working Group would like to ask that `self.performance.now()` be exposed in AudioWorklet.

There is desire from the Web Audio community, and positive comments from browser implementers (please refer to the linked issue).

Implementation commitment:
- [ ] WebKit (no signal)
- [x] [Chromium](https://crbug.com/392542574)
- [ ] Gecko (positive based on issue comments and meeting)