### PR TITLE
Add 'attribute' keyword to IDL attribute dfns for Bikeshed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,7 @@ worker.port.onmessage = function (event) {
 <p>
   Each [=clock=]'s <a href="#unsafe-current-time">unsafe current time</a> returns an <dfn>unsafe
   moment</dfn>. [=Coarsen time=] converts these [=unsafe moments=] to
-  <dfn data-export data-lt="moment" id=dfn-moment>coarsened moments</dfn> or just
+  <dfn data-export data-lt="moment|coarsened moments" id=dfn-moment>coarsened moments</dfn> or just
   [=moments=]. [=Unsafe moments=] and [=moments=] from different clocks
   are not comparable.
 </p>
@@ -677,7 +677,7 @@ interface Performance : EventTarget {
   <code>timeOrigin</code> attribute
 </h3>
 <p data-tests="timeOrigin.html, window-worker-timeOrigin.window.html">
-  The <dfn data-export>timeOrigin</dfn> attribute MUST return the number of
+  The <dfn attribute for="Performance" data-export>timeOrigin</dfn> attribute MUST return the number of
   milliseconds in the [=duration=] returned by [=get time origin
   timestamp=] for the [=relevant global object=] of [=this=].
 </p>
@@ -706,7 +706,7 @@ interface Performance : EventTarget {
   The <code>performance</code> attribute
 </h3>
 <p>
-  The <dfn data-export id="the-performance-attr">performance</dfn> attribute on the interface mixin
+  The <dfn attribute for="WindowOrWorkerGlobalScope" data-export id="the-performance-attr">performance</dfn> attribute on the interface mixin
   {{WindowOrWorkerGlobalScope}} allows access to performance related
   attributes and methods from the [=/global object=].
 </p>


### PR DESCRIPTION
Bikeshed conversion didn't properly handle attributes. This fixes that.
It also fixes a linking error with "coarsened moments".

- chore: fixes unrelated to the spec itself (e.g., fix to Github action, html tidy, spec config, etc.).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/174.html" title="Last updated on Mar 16, 2026, 7:35 AM UTC (916c903)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/174/7573248...916c903.html" title="Last updated on Mar 16, 2026, 7:35 AM UTC (916c903)">Diff</a>