### PR TITLE
Fix broken anchor references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -264,7 +264,7 @@ worker.port.onmessage = function (event) {
 <p>
   Each [=clock=]'s <a href="#unsafe-current-time">unsafe current time</a> returns an <dfn>unsafe
   moment</dfn>. [=Coarsen time=] converts these [=unsafe moments=] to
-  <dfn data-export data-lt="moment" id=dfn-moment>coarsened moments</dfn> or just
+  <dfn data-export data-lt="moment|coarsened moment" id=dfn-moment>coarsened moments</dfn> or just
   [=moments=]. [=Unsafe moments=] and [=moments=] from different clocks
   are not comparable.
 </p>


### PR DESCRIPTION
After the Bikeshed conversion, some anchor IDs changed (e.g. `dfn-` prefixes dropped). This adds `oldids` attributes and fixes link-defaults so cross-spec references resolve correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/pull/175.html" title="Last updated on Mar 24, 2026, 10:13 AM UTC (93fda4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/hr-time/175/7573248...93fda4b.html" title="Last updated on Mar 24, 2026, 10:13 AM UTC (93fda4b)">Diff</a>